### PR TITLE
PDR-23 API Details Get pt 1

### DIFF
--- a/pdr-api/handlers/config/GET/index.js
+++ b/pdr-api/handlers/config/GET/index.js
@@ -4,7 +4,7 @@ const { sendResponse, checkWarmup, logger } = require("/opt/base");
 exports.handler = async (event, context) => {
   logger.debug("Read Config", event);
   if (checkWarmup(event)) {
-    return sendResponse(200, {});
+    return sendResponse(200, [], 'Warm up.', null);
   }
 
   let queryObj = {
@@ -18,9 +18,9 @@ exports.handler = async (event, context) => {
     queryObj.KeyConditionExpression = "pk =:pk AND sk =:sk";
 
     const configData = await runQuery(queryObj);
-    return sendResponse(200, configData[0], context);
+    return sendResponse(200, configData[0], 'Success', null, context);
   } catch (err) {
     logger.error(err);
-    return sendResponse(400, err, context);
+    return sendResponse(400, [], 'Error', err, context);
   }
 };

--- a/pdr-api/handlers/details/GET/index.js
+++ b/pdr-api/handlers/details/GET/index.js
@@ -1,0 +1,95 @@
+const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require("/opt/dynamodb");
+const { sendResponse, logger } = require("/opt/base");
+
+exports.handler = async (event, context) => {
+  logger.debug("Get details", event);
+
+  try {
+    const params = event.queryStringParameters;
+    if (!params || !params.assetType === 'park') {
+      throw {
+        code: 400,
+        error: 'Insufficient paramters.',
+        msg: "You must provide parameters."
+      }
+    }
+
+    // Search by assetType status
+    const status = event.queryStringParameters.status;
+    // Search by assetType identifier (pk)
+    const identifier = event.queryStringParameters.identifier;
+    // Search by legal name
+    const legalName = event.queryStringParameters.legalName;
+
+    if (!status && !identifier && !legalName) {
+      throw {
+        code: 400,
+        error: 'Insufficient parameters.',
+        msg: "You must provide a status, identifier, or legal name to search by."
+      }
+    }
+
+    let query = {};
+
+    if (status) {
+      // We want to filter by status.
+      query = {
+        TableName: TABLE_NAME,
+        IndexName: STATUS_INDEX_NAME,
+        KeyConditionExpression: '#status = :status',
+        ExpressionAttributeNames: {
+          '#status': 'status',
+        },
+        ExpressionAttributeValues: {
+          ':status': { S: status }
+        }
+      }
+    }
+
+    if (identifier) {
+      // We are looking for a specific identifier.
+      // If query already started, add identifier as filter expression.
+      if (Object.keys(query).length > 0) {
+        query.ExpressionAttributeValues[':pk'] = { S: identifier };
+        query.KeyConditionExpression += " AND pk = :pk"
+      } else {
+        // else start new query
+        query = {
+          TableName: TABLE_NAME,
+          KeyConditionExpression: 'pk = :pk',
+          ExpressionAttributeValues: {
+            ':pk': { S: identifier }
+          }
+        }
+      }
+    }
+
+    if (legalName) {
+      // We are searching by legal name.
+      // If query already started, add legalName as a filter expression
+      if (Object.keys(query).length > 0) {
+        query.ExpressionAttributeValues[':legalName'] = { S: legalName };
+        query.FilterExpression = 'legalName = :legalName'
+      } else {
+        // else start new query
+        query = {
+          TableName: TABLE_NAME,
+          IndexName: LEGALNAME_INDEX_NAME,
+          KeyConditionExpression: 'legalName = :legalName',
+          ExpressionAttributeValues: {
+            ':legalName': { S: legalName }
+          }
+        }
+      }
+    }
+
+    logger.debug('Details query:', query);
+    const res = await runQuery(query, 10);
+    logger.debug('Details query result:', res);
+
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (err) {
+    logger.error(err);
+    return sendResponse(err.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+  }
+};

--- a/pdr-api/layers/base/base.js
+++ b/pdr-api/layers/base/base.js
@@ -13,15 +13,29 @@ exports.logger = createLogger({
       if (symbols.length == 2) {
         meta = JSON.stringify(info[symbols[1]]);
       }
-      return `${info.timestamp} ${[info.level.toUpperCase()]}: ${
-        info.message
-      } ${meta}`;
+      return `${info.timestamp} ${[info.level.toUpperCase()]}: ${info.message
+        } ${meta}`;
     })
   ),
   transports: [new transports.Console()],
 });
 
-exports.sendResponse = function (code, data, context) {
+exports.sendResponse = function (code, data, message, error, context, other = null) {
+  // All responses must include the following fields as a minimum.
+  let body = {
+    code: code,
+    data: data,
+    msg: message,
+    error: error,
+  }
+  // If context present, attach it to body
+  if (context) {
+    body['context'] = context;
+  }
+  // If other fields are present, attach them to the body.
+  if (other) {
+    body = Object.assign(body, object);
+  }
   const response = {
     statusCode: code,
     headers: {
@@ -31,7 +45,7 @@ exports.sendResponse = function (code, data, context) {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "OPTIONS,GET,POST",
     },
-    body: JSON.stringify(data),
+    body: JSON.stringify(body),
   };
   return response;
 };

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -62,7 +62,7 @@ Resources:
     FunctionName: ConfigGet
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: handlers/config/GET/
+      CodeUri: handlers/config/GET
       Handler: index.handler
       Layers:
         - !Ref BaseLayer
@@ -84,6 +84,36 @@ Resources:
           Type: Api
           Properties:
             Path: /config
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+
+  # Config
+  DetailsGet:
+    FunctionName: DetailsGet
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/details/GET
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref DynamoDBLayer
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Details GET lambda function
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref NameRegister
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref NameRegister
+      Events:
+        DetailsGet:
+          Type: Api
+          Properties:
+            Path: /details
             Method: GET
             RestApiId: !Ref ApiDeployment
 


### PR DESCRIPTION
This change introduces a `/details` endpoint for the API. 

You must provide `assetType=park` as a query parameter to access park names.

You must also provide one or more of the following parameters:

- status: `status=current` -  queries on the `byStatusOfOrcs` GSI.
- identifier: `identifier=1` - the identifier (pk) of the assetType - this is ORCS/ParkID for parks (no leading zeroes).
- legalName: `legalName=Strathcona Park` - the legal name of the assetType.

If you supply more than one of the above parameters, you will only get results that match every parameter supplied.

Testing files and Postman in progress. 