### PR TITLE
PDR-23 park names api part 1

### DIFF
--- a/pdr-api/handlers/config/GET/index.js
+++ b/pdr-api/handlers/config/GET/index.js
@@ -4,7 +4,7 @@ const { sendResponse, checkWarmup, logger } = require("/opt/base");
 exports.handler = async (event, context) => {
   logger.debug("Read Config", event);
   if (checkWarmup(event)) {
-    return sendResponse(200, {});
+    return sendResponse(200, [], 'Warm up.', null);
   }
 
   let queryObj = {
@@ -18,9 +18,9 @@ exports.handler = async (event, context) => {
     queryObj.KeyConditionExpression = "pk =:pk AND sk =:sk";
 
     const configData = await runQuery(queryObj);
-    return sendResponse(200, configData[0], context);
+    return sendResponse(200, configData[0], 'Success', null, context);
   } catch (err) {
     logger.error(err);
-    return sendResponse(400, err, context);
+    return sendResponse(400, [], 'Error', err, context);
   }
 };

--- a/pdr-api/handlers/parks/$identifier/name/GET/index.js
+++ b/pdr-api/handlers/parks/$identifier/name/GET/index.js
@@ -1,0 +1,41 @@
+
+const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require("/opt/dynamodb");
+const { sendResponse, logger } = require("/opt/base");
+
+exports.handler = async (event, context) => {
+  logger.debug("Get park name details", event);
+
+  try {
+    const identifier = event.pathParameters.identifier;
+    const status = event.queryStringParameters?.status || null;
+
+    // Get name name-related data
+    // Currently only have to filter by pk as everything in the db is name-related data
+    // This may change if data other than name data is stored within the pk identifier.
+    let query = {
+      TableName: TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: {
+        ':pk': { S: identifier },
+      },
+    }
+
+    // If status provided, switch index to filter by status
+    if (status) {
+      query.IndexName = STATUS_INDEX_NAME;
+      query.KeyConditionExpression += ' AND #status = :status';
+      query['ExpressionAttributeNames'] = { '#status': 'status' };
+      query.ExpressionAttributeValues[':status'] = { S: status };
+    }
+
+    logger.debug('Get park name query', query);
+    const res = await runQuery(query);
+    logger.debug('Get park name result', res);
+
+
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (err) {
+    logger.error(err);
+    return sendResponse(err.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+  }
+};

--- a/pdr-api/handlers/parks/names/GET/index.js
+++ b/pdr-api/handlers/parks/names/GET/index.js
@@ -1,0 +1,69 @@
+
+const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require("/opt/dynamodb");
+const { sendResponse, logger } = require("/opt/base");
+
+exports.handler = async (event, context) => {
+  logger.debug("Get all park names details", event);
+
+  try {
+    const queryParams = event.queryStringParameters;
+
+    let query = {};
+
+    if (queryParams?.legalName) {
+      // We want to search by legal name
+      query = queryByLegalName(queryParams.legalName, queryParams?.status)
+    } else if (queryParams?.status) {
+      // We want to get park names by status
+      query = queryByStatus(queryParams.status)
+    } else {
+      throw {
+        code: 400,
+        error: 'Insufficient parameters.',
+        msg: `Missing at least one required query parameter: 'status' or 'legalName'`
+      }
+    }
+
+    logger.debug('Get all park names query', query);
+    const res = await runQuery(query);
+    logger.debug('Get all park names result', res);
+
+    return sendResponse(200, res, 'Success', null, context);
+  } catch (err) {
+    logger.error(err);
+    return sendResponse(err.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+  }
+};
+
+function queryByLegalName(legalName, status = null) {
+  let query = {
+    TableName: TABLE_NAME,
+    IndexName: LEGALNAME_INDEX_NAME,
+    KeyConditionExpression: 'legalName = :legalName',
+    ExpressionAttributeValues: {
+      ':legalName': { S: legalName }
+    }
+  }
+
+  if (status) {
+    query.FilterExpression = '#status = :status';
+    query['ExpressionAttributeNames'] = { '#status': 'status' };
+    query.ExpressionAttributeValues[':status'] = { S: status };
+  }
+
+  return query;
+}
+
+function queryByStatus(status) {
+  return {
+    TableName: TABLE_NAME,
+    IndexName: STATUS_INDEX_NAME,
+    KeyConditionExpression: '#status = :status',
+    ExpressionAttributeNames: {
+      '#status': 'status'
+    },
+    ExpressionAttributeValues: {
+      ':status': { S: status }
+    }
+  }
+}

--- a/pdr-api/layers/base/base.js
+++ b/pdr-api/layers/base/base.js
@@ -13,15 +13,25 @@ exports.logger = createLogger({
       if (symbols.length == 2) {
         meta = JSON.stringify(info[symbols[1]]);
       }
-      return `${info.timestamp} ${[info.level.toUpperCase()]}: ${
-        info.message
-      } ${meta}`;
+      return `${info.timestamp} ${[info.level.toUpperCase()]}: ${info.message
+        } ${meta}`;
     })
   ),
   transports: [new transports.Console()],
 });
 
-exports.sendResponse = function (code, data, context) {
+exports.sendResponse = function (code, data, message, error, context, other = null) {
+  // All responses must include the following fields as a minimum.
+  let body = {
+    code: code,
+    data: data,
+    msg: message,
+    error: error,
+  }
+  // If other fields are present, attach them to the body.
+  if (other) {
+    body = Object.assign(body, object);
+  }
   const response = {
     statusCode: code,
     headers: {
@@ -31,7 +41,7 @@ exports.sendResponse = function (code, data, context) {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "OPTIONS,GET,POST",
     },
-    body: JSON.stringify(data),
+    body: JSON.stringify(body),
   };
   return response;
 };

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -62,7 +62,7 @@ Resources:
     FunctionName: ConfigGet
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: handlers/config/GET/
+      CodeUri: handlers/config/GET
       Handler: index.handler
       Layers:
         - !Ref BaseLayer
@@ -84,6 +84,66 @@ Resources:
           Type: Api
           Properties:
             Path: /config
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+
+  # ParksAllNamesGet
+  ParksAllNamesGet:
+    FunctionName: ParksAllNamesGet
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/parks/names/GET
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref DynamoDBLayer
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: All Park Names GET lambda function
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref NameRegister
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref NameRegister
+      Events:
+        ParksAllNamesGet:
+          Type: Api
+          Properties:
+            Path: /parks/names
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+
+  # ParkNameGet
+  ParkNameGet:
+    FunctionName: ParkNameGet
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/parks/$identifier/name/GET
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref DynamoDBLayer
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Park Name GET lambda function
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref NameRegister
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref NameRegister
+      Events:
+        ParkNameGet:
+          Type: Api
+          Properties:
+            Path: /parks/{identifier}/name
             Method: GET
             RestApiId: !Ref ApiDeployment
 


### PR DESCRIPTION
Resolves #23.

This change introduces a couple of park name endpoints for the API.

To if you know the `identifier` (pk, parkID, orcs) for the park you are looking up, use the endpoint:

`/park/{identifier}/name` 

to get the relevant name data. Add `status=current` as a query param to get the most up to date name.

If you do not know the specific park, there is an endpoint for name data for all parks at

`/parks/names`

where you must provide at least one of two query parameters:

- `status=current`: get the list of current park names
- `legalName={legalName}`: search by legal name

Ex:
 `/park/1/name?status=current` will give the current name for ParkID 1 (Strathcona Park)
`/parks/names?status=current` will get you a list of all current names.

Testing files and Postman in progress.

Note: There are some fundamental changes to our query, scan and sendResponse functionalities in our new Layers compared to previous projects. As this will be a publicly consumed API, it is important to standardize our responses.