### PR TITLE
API-137: Adding preliminary authorizers to APIGW.

### DIFF
--- a/pdr-api/handlers/authorizer/index.js
+++ b/pdr-api/handlers/authorizer/index.js
@@ -1,0 +1,67 @@
+const { decodeJWT, resolvePermissions } = require('/opt/permissions');
+const { logger } = require('/opt/base');
+
+const publicPermissionObject = {
+  isAdmin: false,
+  role: ['public']
+};
+
+exports.handler = async function (event, context, callback) {
+  logger.debug('event', JSON.stringify(event));
+
+  if (!event.headers.Authorization) {
+    logger.debug('No authorization header provided.');
+    return 'No authorization header provided.';
+  }
+
+  if (event.headers.Authorization === 'None') {
+    // Public user.
+    return generatePolicy('public', 'Allow', event.methodArn, publicPermissionObject);
+  }
+
+  var token = await decodeJWT(event);
+  logger.debug('token', JSON.stringify(token));
+
+  if (!token.decoded) {
+    logger.debug('Issue decoding token.');
+    return 'Error: Invalid token';
+  }
+
+  const permissionObject = resolvePermissions(token);
+  logger.debug('permissionObject', JSON.stringify(permissionObject));
+  if (!permissionObject.isAuthenticated) {
+    logger.debug('User is not authenticated.');
+    return 'Unauthorized';
+  }
+
+  // Sysadmin
+  logger.debug('User authenticated.');
+  return generatePolicy(token.sid, 'Allow', event.methodArn, permissionObject);
+};
+
+// Help function to generate an IAM policy
+var generatePolicy = function (principalId, effect, methodArn, permissionObject) {
+  logger.debug('principalId', principalId);
+  var authResponse = {};
+
+  authResponse.principalId = principalId;
+  if (effect && methodArn) {
+    var policyDocument = {};
+    policyDocument.Version = '2012-10-17';
+    policyDocument.Statement = [];
+    var statementOne = {};
+    statementOne.Action = 'execute-api:Invoke';
+    statementOne.Effect = effect;
+    statementOne.Resource = methodArn;
+    policyDocument.Statement[0] = statementOne;
+    authResponse.policyDocument = policyDocument;
+  }
+
+  // Optional output with custom properties of the String, Number or Boolean type.
+  authResponse.context = {
+    isAdmin: permissionObject?.isAdmin,
+    role: JSON.stringify(permissionObject?.roles)
+  };
+  logger.debug('authResponse', JSON.stringify(authResponse));
+  return authResponse;
+};

--- a/pdr-api/handlers/authorizer/index.js
+++ b/pdr-api/handlers/authorizer/index.js
@@ -19,7 +19,7 @@ exports.handler = async function (event, context, callback) {
     return generatePolicy('public', 'Allow', event.methodArn, publicPermissionObject);
   }
 
-  var token = await decodeJWT(event);
+  let token = await decodeJWT(event);
   logger.debug('token', JSON.stringify(token));
 
   if (!token.decoded) {
@@ -40,16 +40,16 @@ exports.handler = async function (event, context, callback) {
 };
 
 // Help function to generate an IAM policy
-var generatePolicy = function (principalId, effect, methodArn, permissionObject) {
+let generatePolicy = function (principalId, effect, methodArn, permissionObject) {
   logger.debug('principalId', principalId);
-  var authResponse = {};
+  let authResponse = {};
 
   authResponse.principalId = principalId;
   if (effect && methodArn) {
-    var policyDocument = {};
+    let policyDocument = {};
     policyDocument.Version = '2012-10-17';
     policyDocument.Statement = [];
-    var statementOne = {};
+    let statementOne = {};
     statementOne.Action = 'execute-api:Invoke';
     statementOne.Effect = effect;
     statementOne.Resource = methodArn;

--- a/pdr-api/handlers/config/GET/index.js
+++ b/pdr-api/handlers/config/GET/index.js
@@ -1,24 +1,24 @@
-const { runQuery, TABLE_NAME } = require("/opt/dynamodb");
-const { sendResponse, checkWarmup, logger } = require("/opt/base");
+const { runQuery, TABLE_NAME } = require('/opt/dynamodb');
+const { sendResponse, checkWarmup, logger } = require('/opt/base');
 
 exports.handler = async (event, context) => {
-  logger.debug("Read Config", event);
+  logger.debug('Read Config', event);
   if (checkWarmup(event)) {
     return sendResponse(200, [], 'Warm up.', null);
   }
 
   let queryObj = {
-    TableName: TABLE_NAME,
+    TableName: TABLE_NAME
   };
 
   try {
     queryObj.ExpressionAttributeValues = {};
-    queryObj.ExpressionAttributeValues[":pk"] = { S: "config" };
-    queryObj.ExpressionAttributeValues[":sk"] = { S: "config" };
-    queryObj.KeyConditionExpression = "pk =:pk AND sk =:sk";
+    queryObj.ExpressionAttributeValues[':pk'] = { S: 'config' };
+    queryObj.ExpressionAttributeValues[':sk'] = { S: 'config' };
+    queryObj.KeyConditionExpression = 'pk =:pk AND sk =:sk';
 
     const configData = await runQuery(queryObj);
-    return sendResponse(200, configData[0], 'Success', null, context);
+    return sendResponse(200, configData.items[0], 'Success', null, context);
   } catch (err) {
     logger.error(err);
     return sendResponse(400, [], 'Error', err, context);

--- a/pdr-api/handlers/parks/_identifier/name/GET/index.js
+++ b/pdr-api/handlers/parks/_identifier/name/GET/index.js
@@ -51,7 +51,7 @@ exports.handler = async (event, context) => {
 function validateRequest(queryParams, isAdmin) {
   if (!isAdmin && queryParams?.status === 'pending') {
     // Public users are not allowed to see pending park names
-    throw 'Not authorized';
+    throw new Error('Not authorized');
   }
 }
 

--- a/pdr-api/handlers/parks/_identifier/name/GET/index.js
+++ b/pdr-api/handlers/parks/_identifier/name/GET/index.js
@@ -1,13 +1,18 @@
-
-const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require("/opt/dynamodb");
-const { sendResponse, logger } = require("/opt/base");
+const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require('/opt/dynamodb');
+const { sendResponse, logger } = require('/opt/base');
 
 exports.handler = async (event, context) => {
-  logger.debug("Get park name details", event);
+  logger.debug('Get park name details', event);
 
   try {
     const identifier = event.pathParameters.identifier;
     const status = event.queryStringParameters?.status || null;
+
+    const queryParams = event.queryStringParameters;
+    const isAdmin = JSON.parse(event.requestContext.authorizer.isAdmin);
+
+    // Check if query is valid
+    validateRequest(queryParams, isAdmin);
 
     // Get name name-related data
     // Currently only have to filter by pk as everything in the db is name-related data
@@ -16,9 +21,9 @@ exports.handler = async (event, context) => {
       TableName: TABLE_NAME,
       KeyConditionExpression: 'pk = :pk',
       ExpressionAttributeValues: {
-        ':pk': { S: identifier },
-      },
-    }
+        ':pk': { S: identifier }
+      }
+    };
 
     // If status provided, switch index to filter by status
     if (status) {
@@ -28,10 +33,13 @@ exports.handler = async (event, context) => {
       query.ExpressionAttributeValues[':status'] = { S: status };
     }
 
+    if (!isAdmin) {
+      query = setPublicFilters(query, queryParams);
+    }
+
     logger.debug('Get park name query', query);
     const res = await runQuery(query);
     logger.debug('Get park name result', res);
-
 
     return sendResponse(200, res, 'Success', null, context);
   } catch (err) {
@@ -39,3 +47,27 @@ exports.handler = async (event, context) => {
     return sendResponse(err.code || 400, [], err?.msg || 'Error', err?.error || err, context);
   }
 };
+
+function validateRequest(queryParams, isAdmin) {
+  if (!isAdmin && queryParams?.status === 'pending') {
+    // Public users are not allowed to see pending park names
+    throw 'Not authorized';
+  }
+}
+
+function setPublicFilters(query, queryParams) {
+  if (!queryParams?.status) {
+    // If user is public, we redact status = pending
+    logger.info('User is public, redacting pending names.');
+    query.ExpressionAttributeValues[':pending'] = { S: 'pending' };
+    if (!query.ExpressionAttributeNames) {
+      query.ExpressionAttributeNames = {};
+    }
+    query.ExpressionAttributeNames['#status'] = 'status';
+    query.FilterExpression = '#status <> :pending';
+  }
+  // If status is already being filtered then we can skip.
+  // We can assume that validateRequest has already removed the case where status = pending and user is public
+
+  return query;
+}

--- a/pdr-api/handlers/parks/names/GET/index.js
+++ b/pdr-api/handlers/parks/names/GET/index.js
@@ -78,7 +78,7 @@ function queryByStatus(status) {
 function validateRequest(queryParams, isAdmin) {
   if (!isAdmin && queryParams?.status === 'pending') {
     // Public users are not allowed to see pending park names
-    throw 'Not authorized';
+    throw new Error('Not authorized');
   }
 }
 

--- a/pdr-api/handlers/parks/names/GET/index.js
+++ b/pdr-api/handlers/parks/names/GET/index.js
@@ -1,27 +1,34 @@
-
-const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require("/opt/dynamodb");
-const { sendResponse, logger } = require("/opt/base");
+const { runQuery, TABLE_NAME, STATUS_INDEX_NAME, LEGALNAME_INDEX_NAME } = require('/opt/dynamodb');
+const { sendResponse, logger } = require('/opt/base');
 
 exports.handler = async (event, context) => {
-  logger.debug("Get all park names details", event);
+  logger.debug('Get all park names details', event);
 
   try {
     const queryParams = event.queryStringParameters;
+    const isAdmin = JSON.parse(event.requestContext.authorizer.isAdmin);
+
+    // Check if query is valid
+    validateRequest(queryParams, isAdmin);
 
     let query = {};
 
     if (queryParams?.legalName) {
       // We want to search by legal name
-      query = queryByLegalName(queryParams.legalName, queryParams?.status)
+      query = queryByLegalName(queryParams.legalName, queryParams?.status);
     } else if (queryParams?.status) {
       // We want to get park names by status
-      query = queryByStatus(queryParams.status)
+      query = queryByStatus(queryParams.status);
     } else {
       throw {
         code: 400,
         error: 'Insufficient parameters.',
         msg: `Missing at least one required query parameter: 'status' or 'legalName'`
-      }
+      };
+    }
+
+    if (!isAdmin) {
+      query = setPublicFilters(query, queryParams);
     }
 
     logger.debug('Get all park names query', query);
@@ -43,7 +50,7 @@ function queryByLegalName(legalName, status = null) {
     ExpressionAttributeValues: {
       ':legalName': { S: legalName }
     }
-  }
+  };
 
   if (status) {
     query.FilterExpression = '#status = :status';
@@ -65,5 +72,29 @@ function queryByStatus(status) {
     ExpressionAttributeValues: {
       ':status': { S: status }
     }
+  };
+}
+
+function validateRequest(queryParams, isAdmin) {
+  if (!isAdmin && queryParams?.status === 'pending') {
+    // Public users are not allowed to see pending park names
+    throw 'Not authorized';
   }
+}
+
+function setPublicFilters(query, queryParams) {
+  if (!queryParams?.status) {
+    // If user is public, we redact status = pending
+    logger.info('User is public, redacting pending names.');
+    query.ExpressionAttributeValues[':pending'] = { S: 'pending' };
+    if (!query.ExpressionAttributeNames) {
+      query.ExpressionAttributeNames = {};
+    }
+    query.ExpressionAttributeNames['#status'] = 'status';
+    query.FilterExpression = '#status <> :pending';
+  }
+  // If status is already being filtered then we can skip.
+  // We can assume that validateRequest has already removed the case where status = pending and user is public
+
+  return query;
 }

--- a/pdr-api/layers/dynamodb/dynamodb.js
+++ b/pdr-api/layers/dynamodb/dynamodb.js
@@ -1,16 +1,17 @@
-const AWS = require("aws-sdk");
-const { logger } = require("/opt/base");
+const AWS = require('aws-sdk');
+const { logger } = require('/opt/base');
 
-const TABLE_NAME = process.env.TABLE_NAME || "NameRegister";
-const STATUS_INDEX_NAME = process.env.STATUS_INDEX_NAME || "ByStatusOfOrcs";
-const LEGALNAME_INDEX_NAME = process.env.STATUS_INDEX_NAME || "ByLegalName";
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister';
+const AWS_REGION = process.env.AWS_REGION || 'ca-central-1';
+const STATUS_INDEX_NAME = process.env.STATUS_INDEX_NAME || 'ByStatusOfOrcs';
+const LEGALNAME_INDEX_NAME = process.env.STATUS_INDEX_NAME || 'ByLegalName';
 
 const options = {
-  region: "ca-central-1",
+  region: AWS_REGION
 };
 
 if (process.env.IS_OFFLINE) {
-  options.endpoint = "http://localhost:8000";
+  options.endpoint = 'http://localhost:8000';
 }
 
 const dynamodb = new AWS.DynamoDB(options);
@@ -22,14 +23,14 @@ async function getOne(pk, sk) {
   logger.info(`getItem: { pk: ${pk}, sk: ${sk} }`);
   const params = {
     TableName: TABLE_NAME,
-    Key: AWS.DynamoDB.Converter.marshall({ pk, sk }),
+    Key: AWS.DynamoDB.Converter.marshall({ pk, sk })
   };
   let item = await dynamodb.getItem(params).promise();
   return item?.Item || {};
 }
 
 async function runQuery(query, limit = null, lastEvaluatedKey = null, paginated = true) {
-  logger.info("query:", query);
+  logger.info('query:', query);
   let data = [];
   let pageData = [];
   let page = 0;
@@ -50,22 +51,18 @@ async function runQuery(query, limit = null, lastEvaluatedKey = null, paginated 
     }
     pageData = await dynamodb.query(query).promise();
     data = data.concat(
-      pageData.Items.map((item) => {
+      pageData.Items.map(item => {
         return AWS.DynamoDB.Converter.unmarshall(item);
       })
     );
     if (page < 2) {
       logger.debug(`Page ${page} data:`, data);
     } else {
-      logger.info(
-        `Page ${page} contains ${pageData.Items.length} additional query results...`
-      );
+      logger.info(`Page ${page} contains ${pageData.Items.length} additional query results...`);
     }
   } while (pageData?.LastEvaluatedKey && !paginated);
 
-  logger.info(
-    `Query result pages: ${page}, total returned items: ${data.length}`
-  );
+  logger.info(`Query result pages: ${page}, total returned items: ${data.length}`);
   if (paginated) {
     return {
       lastEvaluatedKey: pageData.LastEvaluatedKey,
@@ -74,12 +71,12 @@ async function runQuery(query, limit = null, lastEvaluatedKey = null, paginated 
   } else {
     return {
       items: data
-    }
+    };
   }
 }
 
 async function runScan(query, limit = null, lastEvaluatedKey = null, paginated = true) {
-  logger.info("query:", query);
+  logger.info('query:', query);
   let data = [];
   let pageData = [];
   let page = 0;
@@ -100,22 +97,18 @@ async function runScan(query, limit = null, lastEvaluatedKey = null, paginated =
     }
     pageData = await dynamodb.scan(query).promise();
     data = data.concat(
-      pageData.Items.map((item) => {
+      pageData.Items.map(item => {
         return AWS.DynamoDB.Converter.unmarshall(item);
       })
     );
     if (page < 2) {
       logger.debug(`Page ${page} data:`, data);
     } else {
-      logger.info(
-        `Page ${page} contains ${pageData.Items.length} additional scan results...`
-      );
+      logger.info(`Page ${page} contains ${pageData.Items.length} additional scan results...`);
     }
   } while (pageData?.LastEvaluatedKey && !paginated);
 
-  logger.info(
-    `Scan result pages: ${page}, total returned items: ${data.length}`
-  );
+  logger.info(`Scan result pages: ${page}, total returned items: ${data.length}`);
   if (paginated) {
     return {
       lastEvaluatedKey: pageData.LastEvaluatedKey,
@@ -124,23 +117,24 @@ async function runScan(query, limit = null, lastEvaluatedKey = null, paginated =
   } else {
     return {
       items: data
-    }
+    };
   }
 }
 
 // TODO: Remove this, it is unused.
 async function getConfig() {
-  const config = await getOne("config", "config");
+  const config = await getOne('config', 'config');
   return AWS.DynamoDB.Converter.unmarshall(config);
 }
 
 module.exports = {
   TABLE_NAME,
+  AWS_REGION,
   STATUS_INDEX_NAME,
   LEGALNAME_INDEX_NAME,
   dynamodb,
   runQuery,
   runScan,
   getOne,
-  getConfig,
+  getConfig
 };

--- a/pdr-api/layers/permissions/permissions.js
+++ b/pdr-api/layers/permissions/permissions.js
@@ -116,7 +116,7 @@ function verifySecret(tokenString, secret, callback, sendError) {
 }
 
 async function roleFilter(records, roles) {
-  return new Promise(async resolve => {
+  return new Promise(resolve => {
     const data = records.filter(record => {
       logger.debug('record:', record.roles);
       // Sanity check if `roles` isn't defined on reacord. Default to readable.

--- a/pdr-api/postman/Parks Data Register.postman_collection.json
+++ b/pdr-api/postman/Parks Data Register.postman_collection.json
@@ -1,15 +1,27 @@
 {
 	"info": {
-		"_postman_id": "f8292b65-bc66-46d1-81d8-4327cee1959b",
+		"_postman_id": "a2e251b4-244d-4a97-95c1-7b957fc54cd2",
 		"name": "Parks Data Register",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14509064",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-f8292b65-bc66-46d1-81d8-4327cee1959b?action=share&source=collection_link&creator=14509064"
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		"_exporter_id": "21509305"
 	},
 	"item": [
 		{
 			"name": "Config",
-			"item": []
+			"item": [
+				{
+					"name": "Get Config",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": "{{base_url}}/config"
+					},
+					"response": []
+				}
+			]
 		},
 		{
 			"name": "Parks",
@@ -21,9 +33,15 @@
 							"name": "Get All Parks Names",
 							"request": {
 								"method": "GET",
-								"header": [],
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "None",
+										"type": "text"
+									}
+								],
 								"url": {
-									"raw": "{{base_url}}/parks/names?status=current",
+									"raw": "{{base_url}}/parks/names?legalName=Strathcona Park",
 									"host": [
 										"{{base_url}}"
 									],
@@ -34,12 +52,12 @@
 									"query": [
 										{
 											"key": "status",
-											"value": "current"
+											"value": "current",
+											"disabled": true
 										},
 										{
 											"key": "legalName",
-											"value": "Strathcona Park",
-											"disabled": true
+											"value": "Strathcona Park"
 										}
 									]
 								}
@@ -58,7 +76,13 @@
 									"name": "Get Specific Park Name",
 									"request": {
 										"method": "GET",
-										"header": [],
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "None",
+												"type": "text"
+											}
+										],
 										"url": {
 											"raw": "{{base_url}}/parks/:identifier/name?status=current",
 											"host": [
@@ -94,38 +118,14 @@
 	],
 	"auth": {
 		"type": "oauth2",
-		"oauth2": [
-			{
-				"key": "clientId",
-				"value": "{{client_id}}",
-				"type": "string"
-			},
-			{
-				"key": "accessTokenUrl",
-				"value": "{{access_token_url}}",
-				"type": "string"
-			},
-			{
-				"key": "authUrl",
-				"value": "{{auth_url}}",
-				"type": "string"
-			},
-			{
-				"key": "redirect_uri",
-				"value": "{{callback_url}}",
-				"type": "string"
-			},
-			{
-				"key": "tokenName",
-				"value": "{{token_name}}",
-				"type": "string"
-			},
-			{
-				"key": "addTokenTo",
-				"value": "header",
-				"type": "string"
-			}
-		]
+		"oauth2": {
+			"clientId": "{{client_id}}",
+			"accessTokenUrl": "{{access_token_url}}",
+			"authUrl": "{{auth_url}}",
+			"redirect_uri": "{{callback_url}}",
+			"tokenName": "{{token_name}}",
+			"addTokenTo": "header"
+		}
 	},
 	"event": [
 		{

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -1,8 +1,8 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  pdr-api
-  SAM deployment for Parks Data Register API
+  pdr-api SAM deployment for Parks Data Register API
+
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -24,7 +24,7 @@ Resources:
       ContentUri: layers/base/
       CompatibleRuntimes:
         - nodejs18.x
-      LicenseInfo: "Apache-2.0"
+      LicenseInfo: 'Apache-2.0'
       RetentionPolicy: Retain
     Metadata:
       BuildMethod: makefile
@@ -37,7 +37,7 @@ Resources:
       ContentUri: layers/dynamodb/
       CompatibleRuntimes:
         - nodejs18.x
-      LicenseInfo: "Apache-2.0"
+      LicenseInfo: 'Apache-2.0'
       RetentionPolicy: Retain
     Metadata:
       BuildMethod: makefile
@@ -50,7 +50,7 @@ Resources:
       ContentUri: layers/permissions/
       CompatibleRuntimes:
         - nodejs18.x
-      LicenseInfo: "Apache-2.0"
+      LicenseInfo: 'Apache-2.0'
       RetentionPolicy: Retain
     Metadata:
       BuildMethod: makefile
@@ -76,6 +76,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref NameRegister
+          LOG_LEVEL: info
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref NameRegister
@@ -86,6 +87,8 @@ Resources:
             Path: /config
             Method: GET
             RestApiId: !Ref ApiDeployment
+            Auth:
+              Authorizer: NONE
 
   # ParksAllNamesGet
   ParksAllNamesGet:
@@ -106,6 +109,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref NameRegister
+          LOG_LEVEL: info
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref NameRegister
@@ -136,6 +140,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref NameRegister
+          LOG_LEVEL: info
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref NameRegister
@@ -152,6 +157,15 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: !Ref Stage
+      Auth:
+        DefaultAuthorizer: KCAuthorizer
+        Authorizers:
+          KCAuthorizer:
+            FunctionPayloadType: REQUEST
+            FunctionArn: !GetAtt Authorizer.Arn
+            Identity:
+              Headers:
+                - Authorization
 
   ### DYNAMODB TABLES ###
   ProcessDynamoDBStream:
@@ -163,19 +177,24 @@ Resources:
         - !Ref BaseLayer
         - !Ref DynamoDBLayer
       Runtime: nodejs18.x
-      Policies:
-        - DynamoDBCrudPolicy:
-            TableName: !Ref NameRegister
       Environment:
         Variables:
           LOG_LEVEL: info
-      Events:
-        Stream:
-          Type: DynamoDB
-          Properties:
-            Stream: !GetAtt NameRegister.StreamArn
-            BatchSize: 100
-            StartingPosition: TRIM_HORIZON
+
+  ### AUTHORIZER ###
+  Authorizer:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/authorizer/
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref PermissionsLayer
+        - !Ref DynamoDBLayer
+      Runtime: nodejs18.x
+      Environment:
+        Variables:
+          LOG_LEVEL: info
 
   NameRegister:
     Type: AWS::DynamoDB::Table
@@ -254,5 +273,5 @@ Outputs:
   #   # Find out more about other implicit resources you can reference within SAM
   #   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   ApiDeployment:
-    Description: "API Gateway endpoint URL for Stage for Config function"
-    Value: !Sub "https://${ApiDeployment}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/config/"
+    Description: 'API Gateway endpoint URL for Stage for Config function'
+    Value: !Sub 'https://${ApiDeployment}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/config/'


### PR DESCRIPTION
features #137 

This ticket is to add Lambda Authorizers to our deployment.

At the moment, we have the ability to set authorizers on endpoints. In the case of current state, the config endpoint does not have an authorizer.

When a user sends a request to an endpoint that requires authorization, the request is first sent to our authorizer. The authorizer determines if a bearer token is provided from Keycloak. If that is the case, the token will be decoded to figure out if the user is actually authenticated. The authentication status is reflected in the context returned by the authorizer.

Each Lambda at the moment uses the content of the context to determine what to send back to the user. In the current cases, public users are not allowed to see pending park names.