### PR TITLE
setting SSO Realm vars for each env

### DIFF
--- a/.github/workflows/deploy-api-dev.yaml
+++ b/.github/workflows/deploy-api-dev.yaml
@@ -65,8 +65,10 @@ jobs:
         env:
           STACK_NAME: ${{ vars.PDR_API_STACK_NAME }}
           STAGE: ${{ vars.PDR_API_STAGE }}
+          SSO_ISSUER: ${{ var.SSO_ISSUER }}
+          SSO_JWKSURI: ${{ var.SSO_JWKSURI }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-api-prod.yaml
+++ b/.github/workflows/deploy-api-prod.yaml
@@ -75,8 +75,10 @@ jobs:
         env:
           STACK_NAME: ${{ vars.PDR_API_STACK_NAME }}
           STAGE: ${{ vars.PDR_API_STAGE }}
+          SSO_ISSUER: ${{ var.SSO_ISSUER }}
+          SSO_JWKSURI: ${{ var.SSO_JWKSURI }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-api-test.yaml
+++ b/.github/workflows/deploy-api-test.yaml
@@ -78,8 +78,10 @@ jobs:
         env:
           STACK_NAME: ${{ vars.PDR_API_STACK_NAME }}
           STAGE: ${{ vars.PDR_API_STAGE }}
+          SSO_ISSUER: ${{ var.SSO_ISSUER }}
+          SSO_JWKSURI: ${{ var.SSO_JWKSURI }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI"
 
       - shell: bash
         env:

--- a/pdr-api/.gitignore
+++ b/pdr-api/.gitignore
@@ -210,3 +210,6 @@ $RECYCLE.BIN/
 
 tools/BC Parks Names.csv
 tools/PAR - Parks.csv
+
+# AWS SAM Template env.json for Environment variables
+env.json

--- a/pdr-api/handlers/authorizer/index.js
+++ b/pdr-api/handlers/authorizer/index.js
@@ -1,6 +1,9 @@
 const { decodeJWT, resolvePermissions } = require('/opt/permissions');
 const { logger } = require('/opt/base');
 
+const SSO_ISSUER = process.env.SSO_ISSUER || 'https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation'
+const SSO_JWKSURI = process.env.SSO_JWKSURI || 'https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation/protocol/openid-connect/certs'
+
 const publicPermissionObject = {
   isAdmin: false,
   role: ['public']
@@ -19,7 +22,7 @@ exports.handler = async function (event, context, callback) {
     return generatePolicy('public', 'Allow', event.methodArn, publicPermissionObject);
   }
 
-  let token = await decodeJWT(event);
+  let token = await decodeJWT(event, SSO_ISSUER, SSO_JWKSURI);
   logger.debug('token', JSON.stringify(token));
 
   if (!token.decoded) {

--- a/pdr-api/layers/dynamodb/dynamodb.js
+++ b/pdr-api/layers/dynamodb/dynamodb.js
@@ -10,14 +10,11 @@ const LEGALNAME_INDEX_NAME = process.env.STATUS_INDEX_NAME || "ByLegalName";
 const options = {
   region: AWS_REGION
 };
-
 if (process.env.IS_OFFLINE) {
-  options.endpoint = 'http://localhost:8000';
+  options.endpoint = process.env.AWS_ENDPOINT_URL || 'http://localhost:8000';
 }
 
 const dynamodb = new AWS.DynamoDB(options);
-
-exports.dynamodb = new AWS.DynamoDB();
 
 // simple way to return a single Item by primary key.
 async function getOne(pk, sk) {
@@ -188,6 +185,7 @@ async function batchWriteData(dataToInsert, chunkSize, tableName) {
 
 
 module.exports = {
+  dynamodb,
   TABLE_NAME,
   AWS_REGION,
   AUDIT_TABLE_NAME,

--- a/pdr-api/layers/dynamodb/dynamodb.js
+++ b/pdr-api/layers/dynamodb/dynamodb.js
@@ -185,7 +185,6 @@ async function batchWriteData(dataToInsert, chunkSize, tableName) {
 
 
 module.exports = {
-  dynamodb,
   TABLE_NAME,
   AWS_REGION,
   AUDIT_TABLE_NAME,

--- a/pdr-api/package.json
+++ b/pdr-api/package.json
@@ -8,7 +8,7 @@
     "aws-sdk": "^2.1467.0"
   },
   "scripts": {
-    "start": "sam local start-api --skip-pull-image 2>&1 | tr '\r' '\n'",
+    "start": "sam local start-api --env-vars env.json --skip-pull-image 2>&1 | tr '\r' '\n'",
     "start-full": "yarn build && yarn start",
     "build": "sam build --parallel",
     "test": "export=IS_OFFLINE=1 && export TABLE_NAME=NameRegistry-tests && yarn build && jest --coverage"

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -8,6 +8,13 @@ Description: >
 Globals:
   Function:
     Timeout: 3
+    Environment:
+      Variables:
+        SSO_ISSUER: !Ref SSOIssuerUrl
+        SSO_JWKSURI: !Ref SSOJWKSUri
+        IS_OFFLINE: false
+        AWS_REGION: ca-central-1
+        AWS_ENDPOINT_URL: https://localhost:8000
 
 Parameters:
   Stage:
@@ -35,6 +42,12 @@ Parameters:
   SubnetId:
     Type: String
     Default: 'subnet-0896ff158c3ecdc53'
+  SSOIssuerUrl:
+    Type: String
+    Default: https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation
+  SSOJWKSUri:
+    Type: String
+    Default: https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation/protocol/openid-connect/certs
 
 Resources:
 
@@ -366,6 +379,8 @@ Resources:
       Environment:
         Variables:
           LOG_LEVEL: info
+          SSO_ISSUER: !Ref SSOIssuerUrl  
+          SSO_JWKSURI: !Ref SSOJWKSUri
 
   NameRegister:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
SSO urls are now injected during deployment via GitHub Actions variables. 

Note: With AWS SAM, the local docker container that runs it is self contained and has no concept of local environment variables. when running `sam local start-api` all local env vars must be provided in the `template.yaml`. Env vars can be overwritten via an `env.json` file that might look something like this:

```json
{
  "Parameters": {
    "IS_OFFLINE": true, # mandatory
    "TABLE_NAME": "NameRegister",
    "AWS_REGION": "local-env",
    "AWS_ENDPOINT_URL": "http://172.17.0.1:8000" # dynamodb docker container address
  }
}
```

Locally, run `sam build --env-vars env.json` (or `yarn build` has this automagically built in) to overwrite the vars in `template.yaml` with the contents of your own `env.json`.