### PR TITLE
PDR-167 allowing policy generation for all endpoints at once

### DIFF
--- a/pdr-api/__tests__/settings.js
+++ b/pdr-api/__tests__/settings.js
@@ -1,11 +1,13 @@
-const REGION = 'local-env';
+const AWS_REGION = process.env.AWS_REGION || 'local-env';
 const ENDPOINT = 'http://localhost:8000';
-const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister-tests';
+const DYNAMODB_ENDPOINT_URL = process.env.DYNAMODB_ENDPOINT_URL = ENDPOINT;
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegistry-tests';
 const TIMEZONE = 'America/Vancouver';
 const { DocumentClient } = require('aws-sdk/clients/dynamodb');
 const DBMODEL = require('../docs/dbModel.json');
 const AWS = require('aws-sdk');
-const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+process.env.LOG_LEVEL = 'info';
+process.env.IS_OFFLINE = 'true';
 
 // Set the TABLE_NAME to be the test table name in the database model.
 // process.env.TABLE_NAME = TABLE_NAME;
@@ -14,7 +16,7 @@ DBMODEL.TableName = TABLE_NAME;
 async function createDB(items, tableName = TABLE_NAME) {
 
   const docClient = new DocumentClient({
-    region: REGION,
+    region: AWS_REGION,
     endpoint: ENDPOINT,
     convertEmptyValues: true
   });
@@ -35,7 +37,8 @@ async function createDB(items, tableName = TABLE_NAME) {
 
 module.exports = {
   createDB,
-  REGION,
+  DYNAMODB_ENDPOINT_URL,
+  AWS_REGION,
   ENDPOINT,
   TABLE_NAME,
   TIMEZONE,

--- a/pdr-api/__tests__/setup.js
+++ b/pdr-api/__tests__/setup.js
@@ -1,16 +1,17 @@
 const AWS = require('aws-sdk');
 
-const { REGION, ENDPOINT, DBMODEL } = require('./settings');
+const { AWS_REGION, DBMODEL, DYNAMODB_ENDPOINT_URL } = require('./settings');
 
 module.exports = async () => {
-  const dynamoDb = new AWS.DynamoDB({
-    region: REGION,
-    endpoint: ENDPOINT
+  const dynamodb = new AWS.DynamoDB({
+    region: AWS_REGION,
+    endpoint: DYNAMODB_ENDPOINT_URL
   });
 
   try {
-    await dynamoDb.createTable(DBMODEL).promise();
+    await dynamodb.createTable(DBMODEL).promise();
   } catch (err) {
     console.log('err:', err);
   }
+
 };

--- a/pdr-api/handlers/authorizer/index.js
+++ b/pdr-api/handlers/authorizer/index.js
@@ -39,7 +39,12 @@ exports.handler = async function (event, context, callback) {
 
   // Sysadmin
   logger.debug('User authenticated.');
-  return generatePolicy(token.data.sid, 'Allow', event.methodArn, permissionObject);
+  
+  // extract the base API gateway ARN from the event so that a policy can be generated for all routes
+  // TODO: this will likely have to change to enforce more granular role permissions
+  const methodArn = event.methodArn.replace(`${event.httpMethod}${event.path}`, `*`);
+
+  return generatePolicy(token.data.sid, 'Allow', methodArn, permissionObject);
 };
 
 // Help function to generate an IAM policy

--- a/pdr-api/package.json
+++ b/pdr-api/package.json
@@ -11,7 +11,7 @@
     "start": "sam local start-api --env-vars env.json --skip-pull-image 2>&1 | tr '\r' '\n'",
     "start-full": "yarn build && yarn start",
     "build": "sam build --parallel",
-    "test": "export=IS_OFFLINE=1 && export TABLE_NAME=NameRegistry-tests && yarn build && jest --coverage"
+    "test": "export AWS_REGION=local-env && export TABLE_NAME=NameRegistry-tests && yarn build && jest --coverage"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
The previous authenticator lambda would generate permission policies based on the `methodArn` supplied with the event, then cache the user's successful authentication so repeated authentication was not necessary within the 300s caching window. Unfortunately the `methodArn` included the HTTP method and the subroute associated with the call, so the granted permissions were only for the first subroute called by the user. For future requests, authentication was skipped due to caching, and denied for any other subroute other than the one from the first request.

The authenticator will now attempt to trim off the HTTP method and subroute from the `methodArn` before generating a policy, instead allowing for a wildcard policy to be generated for all API gateway endpoints.

This methodology will probably need to change in the future as we desire more control over our permissions, but for now it will allow users to hit multiple endpoints with the same cached authentication policy.

Solves #167