### PR TITLE
191: Fixing misaligned account ids in envs.

### DIFF
--- a/.github/workflows/deploy-api-dev.yaml
+++ b/.github/workflows/deploy-api-dev.yaml
@@ -70,8 +70,9 @@ jobs:
           KMS_KEY_ARN: ${{ vars.KMS_KEY_ARN }}
           VPC_SG: ${{ vars.VPC_SG }}
           VPC_SUBNET: ${{ vars.VPC_SUBNET }}
+          ACCT_ID: ${{ vars.ACCT_ID }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET" "AccountId=$ACCT_ID"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-api-prod.yaml
+++ b/.github/workflows/deploy-api-prod.yaml
@@ -80,8 +80,9 @@ jobs:
           KMS_KEY_ARN: ${{ vars.KMS_KEY_ARN }}
           VPC_SG: ${{ vars.VPC_SG }}
           VPC_SUBNET: ${{ vars.VPC_SUBNET }}
+          ACCT_ID: ${{ vars.ACCT_ID }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET" "AccountId=$ACCT_ID"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-api-test.yaml
+++ b/.github/workflows/deploy-api-test.yaml
@@ -83,8 +83,9 @@ jobs:
           KMS_KEY_ARN: ${{ vars.KMS_KEY_ARN }}
           VPC_SG: ${{ vars.VPC_SG }}
           VPC_SUBNET: ${{ vars.VPC_SUBNET }}
+          ACCT_ID: ${{ vars.ACCT_ID }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET"
+          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "KMSKeyId=$KMS_KEY_ARN" "SecurityGroupId=$VPC_SG" "SubnetId=$VPC_SUBNET" "AccountId=$ACCT_ID"
 
       - shell: bash
         env:

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -16,6 +16,9 @@ Globals:
         DYNAMODB_ENDPOINT_URL: dynamodb.ca-central-1.amazonaws.com
 
 Parameters:
+  AccountId:
+    Type: String
+    Default: '970582042516'
   Stage:
     Type: String
     Default: api
@@ -84,9 +87,9 @@ Resources:
                   - dynamodb:BatchGetItem
                   - dynamodb:DescribeTable
                   - dynamodb:ConditionCheckItem
-                Resource:
-                  - arn:aws:dynamodb:ca-central-1:970582042516:table/Audit
-                  - arn:aws:dynamodb:ca-central-1:970582042516:table/Audit/index/*
+                Resource: !Sub
+                  - 'arn:aws:dynamodb:ca-central-1:${AccountId}:table/Audit/*'
+                  - AccountId: !Ref AccountId
                 Effect: Allow
         - PolicyName: 'ProcessDynamoDBStreamRolePolicyTwo'
           PolicyDocument:
@@ -96,7 +99,9 @@ Resources:
                 Action:
                   - es:ESHttpPost
                   - es:ESHttpPut
-                Resource: arn:aws:es:ca-central-1:970582042516:domain/data-register/*
+                Resource: !Sub
+                  - 'arn:aws:es:ca-central-1:${AccountId}:domain/data-register/*'
+                  - AccountId: !Ref AccountId
                 Effect: Allow
 
   ## Opensearch
@@ -211,7 +216,7 @@ Resources:
       Description: Search Handler
       Policies:
         - ElasticsearchHttpPostPolicy:
-            DomainName: data-register
+            DomainName: !Ref DomainName
       Environment:
         Variables:
           LOG_LEVEL: info
@@ -366,7 +371,7 @@ Resources:
             TableName: !Ref NameRegister
             TableName: !Ref Audit
         - ElasticsearchHttpPostPolicy:
-            DomainName: data-register
+            DomainName: !Ref DomainName
       Events:
         Stream:
           Type: DynamoDB


### PR DESCRIPTION
Fixes #191 

Added env vars for dev/test/prod so that we can substitute the account id in the github workflow so that perms are working across items in the environment.