### PR TITLE
PDR-224-1 migration + data model change to update PA state and type

### DIFF
--- a/pdr-api/docs/dbModel.json
+++ b/pdr-api/docs/dbModel.json
@@ -27,10 +27,6 @@
       "AttributeType": "S"
     },
     {
-      "AttributeName": "phoneticName",
-      "AttributeType": "S"
-    },
-    {
       "AttributeName": "status",
       "AttributeType": "S"
     }

--- a/pdr-api/docs/nosqlWorkbenchDataModel.json
+++ b/pdr-api/docs/nosqlWorkbenchDataModel.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Mark Lisé",
     "DateCreated": "Aug 10, 2023, 08:57 AM",
-    "DateLastModified": "Oct 18, 2023, 11:13 AM",
+    "DateLastModified": "Nov 24, 2023, 09:09 AM",
     "Description": "Data model for the BC Parks Name Register.",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -65,6 +65,10 @@
         {
           "AttributeName": "lastModifiedBy",
           "AttributeType": "S"
+        },
+        {
+          "AttributeName": "type",
+          "AttributeType": "S"
         }
       ],
       "TableFacets": [
@@ -102,7 +106,8 @@
             "phoneticName",
             "status",
             "audioClip",
-            "notes"
+            "notes",
+            "type"
           ],
           "DataAccess": {
             "MySql": {}
@@ -175,13 +180,16 @@
             "S": "stɹæθˈkoʊnə ˈpɑrk"
           },
           "status": {
-            "S": "current"
+            "S": "established"
           },
           "notes": {
             "S": "Name changed because the old one was terrible"
           },
           "lastModifiedBy": {
             "S": "JUSER"
+          },
+          "type": {
+            "S": "protectedArea"
           }
         },
         {
@@ -201,13 +209,16 @@
             "S": "strath park"
           },
           "status": {
-            "S": "old"
+            "S": "historical"
           },
           "notes": {
             "S": "Initial Park created for BC"
           },
           "lastModifiedBy": {
             "S": "JUSER"
+          },
+          "type": {
+            "S": "protectedArea"
           }
         },
         {
@@ -230,7 +241,7 @@
             "S": "Joffre Lakes"
           },
           "status": {
-            "S": "current"
+            "S": "established"
           },
           "notes": {
             "S": "Initial creation of Joffre"
@@ -240,6 +251,9 @@
           },
           "lastModifiedBy": {
             "S": "JUSER"
+          },
+          "type": {
+            "S": "protectedArea"
           }
         },
         {
@@ -259,13 +273,54 @@
             "S": "strath park"
           },
           "status": {
-            "S": "old"
+            "S": "historical"
           },
           "notes": {
             "S": "Updated name"
           },
           "lastModifiedBy": {
             "S": "JUSER"
+          },
+          "type": {
+            "S": "protectedArea"
+          }
+        },
+        {
+          "pk": {
+            "S": "9876"
+          },
+          "sk": {
+            "S": "Details"
+          },
+          "createDate": {
+            "S": "2023-11-24T14:53:00.000Z"
+          },
+          "updateDate": {
+            "S": "2023-11-24T14:54:00.000Z"
+          },
+          "legalName": {
+            "S": "Repealed Provincial Park"
+          },
+          "displayName": {
+            "S": "Repealed Provincial Park"
+          },
+          "phoneticName": {
+            "S": "rɪˈpild prəˈvɪnʃəl pɑrk"
+          },
+          "status": {
+            "S": "repealed"
+          },
+          "notes": {
+            "S": "Protected area repealed, does not exist anymore."
+          },
+          "searchTerms": {
+            "S": "Established park name"
+          },
+          "lastModifiedBy": {
+            "S": "JUSER"
+          },
+          "type": {
+            "S": "protectedArea"
           }
         }
       ],

--- a/pdr-api/migrations/2023-11-24_updateEstablishedStatus.js
+++ b/pdr-api/migrations/2023-11-24_updateEstablishedStatus.js
@@ -1,0 +1,100 @@
+const AWS = require('aws-sdk');
+const { updateConsoleProgress, finishConsoleUpdates, errorConsoleUpdates } = require('../tools/progressIndicator');
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister';
+
+/*
+  This migration pulls all the protectedArea items in the database and performs the following updates on each item:
+
+    - status: current -> status: established
+    - status: old -> status: historical
+    - new attribute: type: protectedArea
+
+  WARNING: at the time of running this script (2023-11-24), protected areas are the only item type in the database. It likely will not be appropriate to run this migration again in the future. This migration leverages DynamoDB scan.
+*/
+
+// The number of items a transaction can perform at once
+const BATCH_ITEM_LIMIT = 25;
+
+const options = {
+  region: 'ca-central-1'
+};
+
+if (process.env.IS_OFFLINE === 'true') {
+  options.endpoint = process.env.DYNAMODB_ENDPOINT_URL || 'http://localhost:8000';
+}
+
+const dynamodb = new AWS.DynamoDB(options);
+
+async function run() {
+  try {
+    // Get all the items in the database
+    const scan = {
+      TableName: TABLE_NAME
+    }
+    const items = await dynamodb.scan(scan).promise();
+
+    // Iterate through the items and update the necessary fields
+    let updates = [];
+    for (let item of items.Items) {
+      // Future proofing in case this is run again
+      // If the item has a type, this migration has already been run and should be aborted.
+      if (item?.type?.S) {
+        if (item?.type?.S !== 'protectedArea' && item?.type?.S !== 'protected-area'){
+          throw 'Encountered item with attribute `type` != `protectedArea`. This suggests this migration has already been run. Aborting migration.'
+        }
+      }
+      // If the item is the config object, don't touch it
+      if (item?.pk?.S === 'config') {
+        continue;
+      }
+      // If status: current, update to status: established
+      if (item?.status?.S === 'current') {
+        item.status = { S: 'established' };
+      }
+      // If status: old, update to status: historical
+      if (item?.status?.S === 'old') {
+        item.status = { S: 'historical' };
+      }
+      // Add type: protectedArea to every remaining record
+      item['type'] = { S: 'protectedArea' };
+      updates.push(item);
+    }
+    
+    // batchWrite (PUT) the updates. Note batchWriteItems is an overwrite, not an update
+    if (updates.length) {
+      let transactionMap = [];
+      let transactionMapChunk = { RequestItems: { [TABLE_NAME]: [] } };
+      let count = 0;
+      let startTime = new Date();
+      for (let i = 0; i < updates.length; i += BATCH_ITEM_LIMIT) {
+        let updateChunk = updates.slice(i, i + BATCH_ITEM_LIMIT);
+        for (const item of updateChunk) {
+          count++;
+          updateConsoleProgress(startTime, 'Creating batch write object', 10, count, updates.length);
+          const putRequest = {
+            PutRequest: {
+              Item: item
+            }
+          }
+          transactionMapChunk.RequestItems[TABLE_NAME].push(putRequest);
+        }
+        transactionMap.push(transactionMapChunk);
+        transactionMapChunk = { RequestItems: { [TABLE_NAME]: [] } }
+      }
+      finishConsoleUpdates();
+      count = 0;
+      startTime = new Date();
+      for (const chunk of transactionMap) {
+        count++;
+        updateConsoleProgress(startTime, 'Batch writing items', 1, count, transactionMap.length);
+        await dynamodb.batchWriteItem(chunk).promise();
+      }
+      finishConsoleUpdates();
+    }
+
+  } catch (err) {
+    errorConsoleUpdates(err);
+  }
+}
+
+run();

--- a/pdr-api/tools/dataLoad.js
+++ b/pdr-api/tools/dataLoad.js
@@ -60,12 +60,13 @@ async function run() {
         ':legalName': { S: record.legalName },
         ':displayName': { S: record.displayName },
         ':phoneticName': { S: record.phoneticName },
-        ':status': { S: 'current' },
-        ':notes': { S: record['validation note'] }
+        ':status': { S: 'established' },
+        ':notes': { S: record['validation note'] },
+        ':type': { S: 'protectedArea'}
       },
-      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeNames: { '#status': 'status', '#type': 'type' },
       UpdateExpression:
-        'SET createDate = :createDate, updateDate = :updateDate, effectiveDate = :effectiveDate, legalName = :legalName, displayName = :displayName, phoneticName = :phoneticName, #status = :status, notes = :notes',
+        'SET createDate = :createDate, updateDate = :updateDate, effectiveDate = :effectiveDate, legalName = :legalName, displayName = :displayName, phoneticName = :phoneticName, #status = :status, notes = :notes', '#type': 'type',
       ReturnValues: 'ALL_NEW'
     };
 

--- a/pdr-api/tools/dynamoRestore.js
+++ b/pdr-api/tools/dynamoRestore.js
@@ -1,0 +1,42 @@
+const AWS = require('aws-sdk');
+
+const data = require('./dump.json');
+const { updateConsoleProgress, finishConsoleUpdates, errorConsoleUpdates } = require('./progressIndicator');
+
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister';
+const MAX_TRANSACTION_SIZE = 25;
+
+const options = {
+  region: 'local',
+  endpoint: 'http://localhost:8000'
+}
+
+console.log("USING CONFIG:", options);
+
+const dynamodb = new AWS.DynamoDB(options);
+
+async function run() {
+  console.log("Running importer");
+  let startTime = new Date().getTime();
+  try {
+    for (let i = 0; i < data.Items.length; i += MAX_TRANSACTION_SIZE) {
+      updateConsoleProgress(startTime, "Importing", 1, i + 1, data.Items.length);
+      let dataChunk = data.Items.slice(i, i + MAX_TRANSACTION_SIZE);
+      let batchWriteChunk = { RequestItems: {[TABLE_NAME]: []} };
+      for (const item of dataChunk) {
+        batchWriteChunk.RequestItems[TABLE_NAME].push({
+          PutRequest: {
+            Item: item
+          }
+        });
+      }
+      await dynamodb.batchWriteItem(batchWriteChunk).promise();
+    }
+    updateConsoleProgress(startTime, "Importing", 1, data.Items.length, data.Items.length);
+    finishConsoleUpdates();
+  } catch (error) {
+    errorConsoleUpdates(error);
+  }
+}
+
+run();

--- a/pdr-api/tools/progressIndicator.js
+++ b/pdr-api/tools/progressIndicator.js
@@ -1,0 +1,81 @@
+function formatTime(time) {
+  let sec = parseInt(time / 1000, 10);
+  let hours = Math.floor(sec / 3600);
+  let minutes = Math.floor((sec - (hours * 3600)) / 60);
+  let seconds = sec - (hours * 3600) - (minutes * 60);
+  if (hours < 10) { hours = "0" + hours; }
+  if (minutes < 10) { minutes = "0" + minutes; }
+  if (seconds < 10) { seconds = "0" + seconds; }
+  return hours + ':' + minutes + ':' + seconds;
+}
+
+/**
+ * This function updates the console with the progress of the operation. Get a time stamp (`intervalStartTime = new Date()`)
+ * before the for loop or nested for loop you want to track, then within the loop, place `updateConsoleProgress` where you want to update
+ * the console with the current progress.
+ * 
+ * It will also update the console with the estimated time remaining if the `total` argument is passed.
+ * 
+ * The function continually overwrites the same console line, so be aware when using other instances of `console.log()` within your loop.
+ * To cleanly finish the console updates and move to the next line, call `finishConsoleUpdates()` or `errorConsoleUpdates()`.
+ * 
+ * @param {Date} intervalStartTime - The timestamp before you want to start tracking console progress
+ * @param {string} text - Text blurb to display in the console
+ * @param {number} modulo - The number of loops to wait between updating the console with the current progress. With quick loops with many iterations, updating the 
+ * console frequently can significantly slow down the operation. For example, setting `modulo` to 25 will only update the console every 25 loops.
+ * @param {number} complete - the current number of completed steps (typically loops). For example, if you have a `for (let i = 0; i < n; i++)` loop, then 
+ * you would pass in `i`.
+ * @param {number} total (optional) - if you know the total number of steps you will have, you can pass them it to get a time estimate of how long your loop will
+ * take to complete. For example, if you have a `for (let i = 0; i < n; i++)` loop, you would pass in `n`. If you have an indeterminate number of steps in your 
+ * loop (i.e. `while()`), leave this argument blank.
+ * 
+ * @example
+ * const intervalStartTime = new Date();
+ * for (let i = 0; i < n; i++) {
+ *   updateConsoleProgress(intervalStartTime, 'Processing data', 1, i, n);
+ * }
+ * finishConsoleUpdates();
+ */
+function updateConsoleProgress(intervalStartTime, text, modulo = 1, complete = 0, total) {
+  if (complete % modulo === 0 || complete === total || complete <= 1) {
+    const currentTime = new Date().getTime();
+    let currentElapsed = currentTime - intervalStartTime;
+    let remainingTime = NaN;
+    if (total) {
+      if (complete !== 0) {
+        let totalTime = (total / complete) * currentElapsed;
+        remainingTime = totalTime - currentElapsed;
+      }
+      const percent = (complete / total) * 100;
+      process.stdout.write(` > ${text}: \x1b[33m${complete}/${total}\x1b[0m (\x1b[35m${percent.toFixed(1)}%\x1b[0m) completed in \x1b[36m${formatTime(currentElapsed)}\x1b[0m (\x1b[36m~${formatTime(remainingTime)}\x1b[0m remaining)\r`);
+    } else {
+      process.stdout.write(` > ${text}: \x1b[33m${complete}\x1b[0m completed in \x1b[36m${formatTime(currentElapsed)}\x1b[0m.\r`);
+    }
+  }
+}
+
+/**
+ * Cleanly finish successful console updates and move to the next line.
+ * 
+ * @param {*} msg - Custom completion message. Defaults to 'Complete.'
+ */
+function finishConsoleUpdates(msg = 'Complete.') {
+  process.stdout.write('\n');
+  console.log(` > \x1b[32m${msg}\x1b[0m`);
+}
+
+/**
+ * Cleanly finish console updates with errors and move to the next line.
+ * 
+ * @param {*} error - Custom error message. Defaults to 'Error.'
+ */
+function errorConsoleUpdates(error = 'Error.') {
+  process.stdout.write('\n');
+  console.log(` > \x1b[31m${error}\x1b[0m`);
+}
+
+module.exports = {
+  updateConsoleProgress,
+  finishConsoleUpdates,
+  errorConsoleUpdates
+}


### PR DESCRIPTION
Relates to #224.

This change adds a migration folder to `pdr-api` with a migration to perform the following updates on the DB:

- status `current` becomes status `established`
- status `old` becomes status `historical`
- all items (except `config`) now have type `protectedArea`

This change updates the `dataLoad.js` script to include the proper statuses and the `type` attribute.

The data model has been updated accordingly.

`dynamoRestore,js` and `progressIndicator.js` have been added to the tools folder for future use. 

Updates to the existing endpoints to accommodate these changes will follow in a future ticket.

