### PR TITLE
NOBUG - adding x-api-key functionality to postman

### DIFF
--- a/pdr-api/postman/Parks Data Register - DEV.postman_environment.json
+++ b/pdr-api/postman/Parks Data Register - DEV.postman_environment.json
@@ -43,9 +43,21 @@
 			"value": "pdr-token-dev",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "vanity_url",
+			"value": "https://dev-data.bcparks.ca/api",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "x-api-key",
+			"value": "",
+			"type": "secret",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-09-20T18:13:17.524Z",
-	"_postman_exported_using": "Postman/10.18.2"
+	"_postman_exported_at": "2023-11-28T16:50:07.982Z",
+	"_postman_exported_using": "Postman/10.20.6"
 }

--- a/pdr-api/postman/Parks Data Register - LOCAL.postman_environment.json
+++ b/pdr-api/postman/Parks Data Register - LOCAL.postman_environment.json
@@ -43,9 +43,21 @@
 			"value": "pdr-token-local",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "vanity_url",
+			"value": "http://localhost:3000",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "x-api-key",
+			"value": "",
+			"type": "secret",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-09-20T18:13:25.300Z",
-	"_postman_exported_using": "Postman/10.18.2"
+	"_postman_exported_at": "2023-11-28T16:50:12.946Z",
+	"_postman_exported_using": "Postman/10.20.6"
 }

--- a/pdr-api/postman/Parks Data Register -TEST.postman_environment.json
+++ b/pdr-api/postman/Parks Data Register -TEST.postman_environment.json
@@ -43,9 +43,21 @@
 			"value": "pdr-token-test",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "vanity_url",
+			"value": "http://test-data.bcparks.ca/api",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "x-api-key",
+			"value": "",
+			"type": "secret",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-09-20T18:13:32.514Z",
-	"_postman_exported_using": "Postman/10.18.2"
+	"_postman_exported_at": "2023-11-28T16:50:17.642Z",
+	"_postman_exported_using": "Postman/10.20.6"
 }

--- a/pdr-api/postman/Parks Data Register.postman_collection.json
+++ b/pdr-api/postman/Parks Data Register.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "4da72fb6-aac3-4f94-bb68-7629c5f4185f",
+		"_postman_id": "5027d9f1-b4d2-4c08-bdab-a9f29a5af674",
 		"name": "Parks Data Register",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "300975"
+		"_exporter_id": "14509064",
+		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-5027d9f1-b4d2-4c08-bdab-a9f29a5af674?action=share&source=collection_link&creator=14509064"
 	},
 	"item": [
 		{
@@ -36,16 +37,20 @@
 			"item": [
 				{
 					"name": "Search",
-					"item":[
+					"item": [
 						{
 							"name": "Search",
 							"request": {
-								"auth": {
-									"type": "inherit"
-								},
-								"method":"GET",
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
+										"type": "text"
+									}
+								],
 								"url": {
-									"raw": "{{base_url}}/search?text=Strathcona Park&status=current&type=protectedArea",
+									"raw": "{{base_url}}/search?text=park",
 									"host": [
 										"{{base_url}}"
 									],
@@ -55,22 +60,23 @@
 									"query": [
 										{
 											"key": "text",
-											"value": "Strathcona Park"
+											"value": "park"
 										},
 										{
 											"key": "status",
-											"value": "current,pending"
+											"value": "current,pending",
+											"disabled": true
 										},
 										{
 											"key": "type",
-											"value": "protectedArea"
+											"value": "protectedArea",
+											"disabled": true
 										}
-
 									]
 								}
-							}
+							},
+							"response": []
 						}
-
 					]
 				},
 				{
@@ -82,8 +88,8 @@
 								"method": "GET",
 								"header": [
 									{
-										"key": "Authorization",
-										"value": "None",
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
 										"type": "text"
 									}
 								],
@@ -125,8 +131,8 @@
 										"method": "GET",
 										"header": [
 											{
-												"key": "Authorization",
-												"value": "None",
+												"key": "x-api-key",
+												"value": "{{x-api-key}}",
 												"type": "text"
 											}
 										],
@@ -160,7 +166,13 @@
 									"name": "Put Specific Park (Minor)",
 									"request": {
 										"method": "PUT",
-										"header": [],
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{x-api-key}}",
+												"type": "text"
+											}
+										],
 										"body": {
 											"mode": "raw",
 											"raw": "{\r\n    \"orcs\": \"1\",\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"legalName\": \"Strathcona Park\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",
@@ -200,7 +212,13 @@
 									"name": "Put Specific Park (Major)",
 									"request": {
 										"method": "PUT",
-										"header": [],
+										"header": [
+											{
+												"key": "x-api-key",
+												"value": "{{x-api-key}}",
+												"type": "text"
+											}
+										],
 										"body": {
 											"mode": "raw",
 											"raw": "{\r\n    \"orcs\": \"1\",\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"legalName\": \"Strathcona Park\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",


### PR DESCRIPTION
This change adds `x-api-key` as a header to all current endpoints that necessitate a key. The header will reference an environment variable that contains the correct key, in a way that keeps the key a secret.

# For developers: 

If you want to send an api key with your requests, the `x-api-key` header is now enabled by default on all requests that need an api key. If you want to remove `x-api-key` from the headers, simple disable (uncheck) the header. Do not delete it entirely. Environment variable files have now been updated with an EMPTY `x-api-key` variable. It is up to the developer to populate this field. Instructions on how to do this follow:

1.  Go into each environment variable file and update the key's CURRENT VALUE to the API key they wish to use. Leave the initial value cell blank.
2. Set the variable type to `secret`.


Environment variable's current values never leave the Postman session, so they are not included in exports nor are they accessible to anyone outside of the session. This makes the current value column an acceptable storage places for API keys. The Initial value column, on the other hand, will be included in environment variable exports, and is accessible by everyone with access to the environment file, so it is best to leave this column blank. Postman will reference the current value column first. 
