### PR TITLE
PDR-264 adding displayId field

### DIFF
--- a/pdr-api/docs/nosqlWorkbenchDataModel.json
+++ b/pdr-api/docs/nosqlWorkbenchDataModel.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Mark Lisé",
     "DateCreated": "Aug 10, 2023, 08:57 AM",
-    "DateLastModified": "Nov 29, 2023, 08:50 AM",
+    "DateLastModified": "Dec 06, 2023, 03:34 PM",
     "Description": "Data model for the BC Parks Name Register.",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -80,6 +80,10 @@
         },
         {
           "AttributeName": "newStatus",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "displayId",
           "AttributeType": "S"
         }
       ],
@@ -171,7 +175,7 @@
       "TableData": [
         {
           "pk": {
-            "S": "0001"
+            "S": "1"
           },
           "sk": {
             "S": "Details"
@@ -202,11 +206,14 @@
           },
           "type": {
             "S": "protectedArea"
+          },
+          "displayId": {
+            "S": "0001"
           }
         },
         {
           "pk": {
-            "S": "0001"
+            "S": "1"
           },
           "sk": {
             "S": "2019-08-10T16:15:50.868Z"
@@ -240,11 +247,14 @@
           },
           "newStatus": {
             "S": "established"
+          },
+          "displayId": {
+            "S": "0001"
           }
         },
         {
           "pk": {
-            "S": "0363"
+            "S": "363"
           },
           "sk": {
             "S": "Details"
@@ -275,11 +285,14 @@
           },
           "type": {
             "S": "protectedArea"
+          },
+          "displayId": {
+            "S": "0363"
           }
         },
         {
           "pk": {
-            "S": "0001"
+            "S": "1"
           },
           "sk": {
             "S": "2020-08-10T16:15:50.868Z"
@@ -313,6 +326,9 @@
           },
           "newStatus": {
             "S": "established"
+          },
+          "displayId": {
+            "S": "0001"
           }
         },
         {
@@ -351,6 +367,9 @@
           },
           "type": {
             "S": "protectedArea"
+          },
+          "displayId": {
+            "S": "9876"
           }
         },
         {
@@ -389,6 +408,9 @@
           },
           "newStatus": {
             "S": "repealed"
+          },
+          "displayId": {
+            "S": "9876"
           }
         }
       ],

--- a/pdr-api/migrations/2023-12-06_addDisplayIdField.js
+++ b/pdr-api/migrations/2023-12-06_addDisplayIdField.js
@@ -1,0 +1,82 @@
+const AWS = require('aws-sdk');
+const { updateConsoleProgress, finishConsoleUpdates, errorConsoleUpdates } = require('../tools/progressIndicator');
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister';
+
+/*
+  This migration adds a populated displayId field to all protected areas.
+  The displayId is the 4-digit leading zero padded pk.
+*/
+
+const BATCH_ITEM_LIMIT = 25;
+
+const options = {
+  region: 'ca-central-1'
+};
+
+if (process.env.IS_OFFLINE === 'true') {
+  options.endpoint = process.env.DYNAMODB_ENDPOINT_URL || 'http://localhost:8000';
+}
+
+const dynamodb = new AWS.DynamoDB(options);
+
+async function run() {
+  try {
+    // get all protectedAreas
+    const scan = {
+      TableName: TABLE_NAME,
+      ExpressionAttributeNames: {
+        '#type': 'type'
+      },
+      ExpressionAttributeValues: {
+        ':type': { S: 'protectedArea' }
+      },
+      FilterExpression: '#type = :type'
+    }
+    const items = await dynamodb.scan(scan).promise();
+
+    // Iterate through the items and add displayId field
+    let updates = [];
+    for (let item of items.Items) {
+      item['displayId'] = { S: String(item.pk.S).padStart(4, '0') };
+      updates.push(item);
+    }
+
+    // batchWrite (PUT) the updates. 
+    if (updates.length) {
+      let transactionMap = [];
+      let transactionMapChunk = { RequestItems: { [TABLE_NAME]: [] } };
+      let count = 0;
+      let startTime = new Date();
+      for (let i = 0; i < updates.length; i += BATCH_ITEM_LIMIT) {
+        let updateChunk = updates.slice(i, i + BATCH_ITEM_LIMIT);
+        for (const item of updateChunk) {
+          count++;
+          updateConsoleProgress(startTime, 'Creating batch write object', 10, count, updates.length);
+          const putRequest = {
+            PutRequest: {
+              Item: item
+            }
+          }
+          transactionMapChunk.RequestItems[TABLE_NAME].push(putRequest);
+        }
+        transactionMap.push(transactionMapChunk);
+        transactionMapChunk = { RequestItems: { [TABLE_NAME]: [] } }
+      }
+      finishConsoleUpdates();
+      count = 0;
+      startTime = new Date();
+      for (const chunk of transactionMap) {
+        count++;
+        updateConsoleProgress(startTime, 'Batch writing items', 1, count, transactionMap.length);
+        await dynamodb.batchWriteItem(chunk).promise();
+      }
+      finishConsoleUpdates();
+    }
+
+
+  } catch (err) {
+    errorConsoleUpdates(err);
+  }
+}
+
+run();


### PR DESCRIPTION
Fixes #264.

Migration adds field `displayId` to the data model - `displayId` is the 4-digit leading zero padded pk.