### PR TITLE
PDR-262 better error handling

### DIFF
--- a/pdr-api/handlers/parks/_identifier/name/PUT/index.js
+++ b/pdr-api/handlers/parks/_identifier/name/PUT/index.js
@@ -315,7 +315,6 @@ async function updateRecord(user, body, currentTimeISO, status, putTransaction =
     if (error?.CancellationReasons) {
       // Check for ConditionalCheckFailed with transactional update.
       conditionalErrorFlag = error.CancellationReasons.find((item) => {
-        console.log('item:', item);
         if (item?.Code === 'ConditionalCheckFailed') {
           return true;
         }


### PR DESCRIPTION
Relates to #262 

For transactional writes, we now extract the error type from the DynamoDB return object.

If you fail to provide the correct `lastVersionDate` value the error message will now be more informative.