### PR TITLE
Url param lifecycle fix

### DIFF
--- a/pdr-admin/src/app/services/url.service.ts
+++ b/pdr-admin/src/app/services/url.service.ts
@@ -1,22 +1,20 @@
-import { Injectable, OnDestroy, OnInit } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class UrlService implements OnInit, OnDestroy {
+export class UrlService implements OnDestroy {
   public queryParams = new BehaviorSubject<any>({});
 
   constructor(
     private router: Router,
     private route: ActivatedRoute
-  ) { }
-
-  ngOnInit() {
+  ) {
     this.route.queryParams.subscribe((changes) => {
       this.queryParams.next(changes);
-    })
+    }) 
   }
 
   /**


### PR DESCRIPTION
grabbing params from the constructor instead of ngoninit