### PR TITLE
PDR-295-2 Adding loadmore button

### DIFF
--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.html
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.html
@@ -72,4 +72,14 @@
   <div *ngIf="data.length === 0" class="table-stripe-dark py-3 ps-2 border-bottom">
     No results. Try a new search.
   </div>
+  <div *ngIf="!searchParams.lastPage && data.length > 0" class="d-flex justify-content-center py-3">
+    <button class="btn btn-outline-secondary" [disabled]="loading" (click)="loadMore()">
+      <div *ngIf="!loading">
+        Load More
+      </div>
+      <div *ngIf="loading" class="spinner-border spinner-border-sm mx-4" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </button>
+  </div>
 </div>

--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
@@ -51,13 +51,13 @@ export class ProtectedAreaSearchComponent implements OnInit {
   ngOnInit(): void {
     this.subscriptions.add(
       this.searchService.watchSearchResults().subscribe((res) => {
-        this.data = res ? res : [];
+        this.data = res || [];
         this.ref.detectChanges();
       })
     );
     this.subscriptions.add(
       this.searchService.watchSearchParams().subscribe((res) => {
-        this.searchParams = res ? res : [];
+        this.searchParams = res || [];
         this.ref.detectChanges();
       })
     );

--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
@@ -33,6 +33,11 @@ export class ProtectedAreaSearchComponent implements OnInit {
     repealedToggle: new UntypedFormControl(false),
   });
 
+  public searchParams = {
+    lastResultIndex: null,
+    lastPage: true
+  }
+
   constructor(
     private router: Router,
     private searchService: SearchService,
@@ -47,6 +52,12 @@ export class ProtectedAreaSearchComponent implements OnInit {
     this.subscriptions.add(
       this.searchService.watchSearchResults().subscribe((res) => {
         this.data = res ? res : [];
+        this.ref.detectChanges();
+      })
+    );
+    this.subscriptions.add(
+      this.searchService.watchSearchParams().subscribe((res) => {
+        this.searchParams = res ? res : [];
         this.ref.detectChanges();
       })
     );
@@ -70,7 +81,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
     if (Object.keys(params).length) {
       params = this.setStatusFilters(params);
       for (const param in params) {
-        if (this.form.controls[param]){
+        if (this.form.controls[param]) {
           this.form.controls[param].setValue(params[param]);
         }
       }
@@ -88,7 +99,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
     }
   }
 
-  async submit(updateQueryParams = true) {
+  async submit(updateQueryParams = true, startFrom = 0) {
     if (this.form.valid) {
       this.form.controls['type'].setValue(this.searchType);
       // If none of the status toggles are true, this is equivalent to all of them being true.
@@ -101,7 +112,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
         // await this change before
         await this.urlService.setQueryParams(urlObj)
       }
-      this.searchService.fetchData(searchObj, this.urlService.getRoute());
+      this.searchService.fetchData(searchObj, this.urlService.getRoute(), startFrom);
     }
   }
 
@@ -151,6 +162,10 @@ export class ProtectedAreaSearchComponent implements OnInit {
         this.router.navigate(['protected-areas', item.pk, 'edit']);
       }
     }
+  }
+
+  loadMore() {
+    this.submit(false, this.searchParams.lastResultIndex);
   }
 
   ngOnDestroy() {

--- a/pdr-admin/src/app/services/api.service.ts
+++ b/pdr-admin/src/app/services/api.service.ts
@@ -16,7 +16,7 @@ export class ApiService implements OnDestroy {
   apiPath: string;
   env: 'local' | 'dev' | 'test' | 'prod';
 
-  constructor(private http: HttpClient, private configService: ConfigService) {}
+  constructor(private http: HttpClient, private configService: ConfigService) { }
 
   // Provide a getter for others to check current state.
   get isNetworkOffline() {
@@ -33,8 +33,12 @@ export class ApiService implements OnDestroy {
 
   init() {
     // If config is setting api, override.
-    if (this.configService.config['API_LOCATION'] && this.configService.config['API_PATH']) {
-      this.apiPath = this.configService.config['API_LOCATION'] + this.configService.config['API_PATH'];
+    if (this.configService.config['API_LOCATION']) {
+      if (this.configService.config['API_PATH']) {
+        this.apiPath = this.configService.config['API_LOCATION'] + this.configService.config['API_PATH'];
+      } else {
+        this.apiPath = this.configService.config['API_LOCATION'];
+      }
     } else {
       this.apiPath = window.location.origin + '/api';
     }

--- a/pdr-admin/src/app/services/search.service.ts
+++ b/pdr-admin/src/app/services/search.service.ts
@@ -15,6 +15,8 @@ import { Utils } from '../utils/utils';
 export class SearchService {
   private utils = new Utils();
 
+  public pageSize = 6;
+
   constructor(
     private dataService: DataService,
     private apiService: ApiService,
@@ -22,20 +24,44 @@ export class SearchService {
     private loggerService: LoggerService,
     private toastService: ToastService,
     private eventService: EventService
-  ) {}
+  ) { }
 
-  async fetchData(queryParams, cacheUrl = null) {
+  async fetchData(queryParams, cacheUrl = null, startFrom = 0) {
     this.loadingService.addToFetchList(Constants.dataIds.SEARCH_RESULTS);
     // Calling API with status = null gives you current and historical
     try {
+      // Start from a certain value if provided
+      queryParams['startFrom'] = startFrom;
+      // Add 1 to the result limit. If the number of results returned is equal to this additional limit, we know there is at least 1 more page of results to query.
+      let lastPage = true;
+      queryParams['limit'] = this.pageSize + 1;
       const res = await lastValueFrom(this.apiService.get('search', queryParams));
       const data = this.apiService.getArrayFromSearchResults(res);
+      if (data.length >= this.pageSize + 1) {
+        // We know theres more pages of results because we were able to bring in more than the page size.
+        // Remove the last result
+        data.pop();
+        lastPage = false;
+      }
+      const lastResultIndex = startFrom + data.length;
       for (let i = 0; i < data.length; i++) {
         data[i] = this.utils.setLastVersionDate(data[i]);
       }
-      this.dataService.setItemValue(Constants.dataIds.SEARCH_RESULTS, data);
+      const searchParams = {
+        lastPage: lastPage,
+        lastResultIndex: lastResultIndex,
+        lastQuery: queryParams
+      }
+      if (startFrom) {
+        // we want to append to the previous results
+        this.dataService.appendItemValue(Constants.dataIds.SEARCH_RESULTS, data);
+      } else {
+        // we want to overwrite the previous results
+        this.dataService.setItemValue(Constants.dataIds.SEARCH_RESULTS, data);
+      }
+      this.dataService.setItemValue(Constants.dataIds.SEARCH_PARAMS, searchParams);
       if (cacheUrl) {
-        this.dataService.setCacheValue(cacheUrl, data, 300);
+        this.dataService.setCacheValue(cacheUrl, this.dataService.getItemValue(Constants.dataIds.SEARCH_RESULTS), 300);
         this.loggerService.debug(`Cache update ${cacheUrl}`);
       }
     } catch (e) {
@@ -49,11 +75,16 @@ export class SearchService {
   watchSearchResults() {
     return this.dataService.watchItem(Constants.dataIds.SEARCH_RESULTS);
   }
+
+  watchSearchParams() {
+    return this.dataService.watchItem(Constants.dataIds.SEARCH_PARAMS);
+  }
+
   clearSearchResults() {
     return this.dataService.clearItemValue(Constants.dataIds.SEARCH_RESULTS);
   }
 
-  checkCache(url){
+  checkCache(url) {
     return this.dataService.getCachedValue(url);
   }
 

--- a/pdr-admin/src/app/utils/constants.ts
+++ b/pdr-admin/src/app/utils/constants.ts
@@ -2,6 +2,7 @@ export class Constants {
   public static readonly dataIds = {
     ENTER_DATA_URL_PARAMS: 'enter-data-url-params',
     SEARCH_RESULTS: 'search-results',
+    SEARCH_PARAMS: 'search-params',
     CURRENT_PROTECTED_AREA: 'current-protected-area',
     PROTECTED_AREA_PUT: 'protected-area-put',
     HISTORICAL_PROTECTED_AREA: 'historical-protected-area',


### PR DESCRIPTION
Fixes #295

Adding `Load More` button to protected area search. 

Default page size is 20 items - this can be changed to whatever. 

Load more will bring in the next 20 items and appending them to the existing results until there are no more results to bring in.