### PR TITLE
PDR-299 fix OS indexing issue

### DIFF
--- a/pdr-api/handlers/dynamoStream/index.js
+++ b/pdr-api/handlers/dynamoStream/index.js
@@ -31,8 +31,8 @@ exports.handler = async function (event, context) {
       let oldImage = record.dynamodb.OldImage;
 
       // Prune the notes field from search
-      delete newImage.notes;
-      delete oldImage.notes;
+      delete newImage?.notes;
+      delete oldImage?.notes;
 
       let createDate = new Date(0);
       createDate.setUTCSeconds(record.dynamodb.ApproximateCreationDateTime);


### PR DESCRIPTION
Fixes #299 

The dynamoStream lambda that updates the OpenSearch index would bork if the notes field was empty on either the old or new indexed item. Adding conditionals to avoid more borking.