### PR TITLE
PDR-230-2 adding /changelog/search endpoint

### DIFF
--- a/pdr-api/docs/nosqlWorkbenchDataModel.json
+++ b/pdr-api/docs/nosqlWorkbenchDataModel.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Mark Lisé",
     "DateCreated": "Aug 10, 2023, 08:57 AM",
-    "DateLastModified": "Dec 06, 2023, 03:34 PM",
+    "DateLastModified": "Dec 22, 2023, 11:16 AM",
     "Description": "Data model for the BC Parks Name Register.",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -85,6 +85,14 @@
         {
           "AttributeName": "displayId",
           "AttributeType": "S"
+        },
+        {
+          "AttributeName": "legalNameChanged",
+          "AttributeType": "BOOL"
+        },
+        {
+          "AttributeName": "statusChanged",
+          "AttributeType": "BOOL"
         }
       ],
       "TableFacets": [
@@ -250,6 +258,12 @@
           },
           "displayId": {
             "S": "0001"
+          },
+          "legalNameChanged": {
+            "BOOL": true
+          },
+          "statusChanged": {
+            "BOOL": false
           }
         },
         {
@@ -329,6 +343,12 @@
           },
           "displayId": {
             "S": "0001"
+          },
+          "legalNameChanged": {
+            "BOOL": true
+          },
+          "statusChanged": {
+            "BOOL": false
           }
         },
         {
@@ -411,6 +431,12 @@
           },
           "displayId": {
             "S": "9876"
+          },
+          "legalNameChanged": {
+            "BOOL": true
+          },
+          "statusChanged": {
+            "BOOL": true
           }
         }
       ],

--- a/pdr-api/handlers/changelog/search/index.js
+++ b/pdr-api/handlers/changelog/search/index.js
@@ -1,0 +1,82 @@
+
+// Import necessary libraries and modules
+const { OSQuery, OPENSEARCH_MAIN_INDEX, nonKeyableTerms } = require('/opt/opensearch');
+const { sendResponse, logger } = require('/opt/base');
+
+// Lambda function entry point
+exports.handler = async function (event, context) {
+  logger.debug('Changelog search:', event); // Log the search event
+  // Allow CORS
+  if (event.httpMethod === 'OPTIONS') {
+    return sendResponse(200, {}, 'Success', null, context);
+  }
+
+  // Check if the user is an admin
+  const isAdmin = event?.requestContext?.authorizer?.isAdmin || false;
+
+  try {
+    // Extract query parameters from the event
+    const queryParams = event.queryStringParameters;
+    // Must provide some kind of filter criteria
+    if (!queryParams) {
+      throw {
+        code: 400,
+        msg: 'Query parameters cannot be empty.',
+        error: 'Invalid request.'
+      }
+    }
+
+    // Build query
+    const query = new OSQuery(OPENSEARCH_MAIN_INDEX, queryParams?.limit, queryParams?.startFrom, queryParams?.sortField, queryParams?.sortOrder);
+
+    // No searching by status in changelog search
+    delete queryParams?.status;
+
+    // Search terms
+    let termQuery = { ...queryParams };
+    delete termQuery?.changeType;
+    for (const term in termQuery) {
+      if (nonKeyableTerms.indexOf(term) > -1) {
+        delete termQuery[term];
+      }
+    }
+    query.addMustMatchTermsRule(termQuery, true);
+
+    // filter status and legalName changes
+    if (queryParams?.changeType) {
+      const changeTypes = queryParams.changeType.split(',');
+      for (const changeType of changeTypes) {
+        query.addShouldMatchTermsRule({ [changeType]: true }, true);
+      }
+    }
+
+    // Search query text
+    if (queryParams?.text) {
+      query.addMatchQueryStringRule(queryParams.text)
+    }
+
+    // search changelog items only (status = historical)
+    query.addMustMatchTermsRule({ status: 'historical' }, true);
+
+    // Perform the search
+    const response = await query.search();
+    logger.debug('Request:', JSON.stringify(query.request, null, 2)); // Log the request (available after sending)
+
+    // Redact the "notes" field if the user is not an admin
+    if (!isAdmin) {
+      for (let i = 0; i < response.body.hits.total.value; i++) {
+        delete response.body.hits.hits[i]?._source?.notes;
+      }
+    }
+
+    logger.debug('Response:', JSON.stringify(response)); // Log the response
+
+    // Send success response
+    return sendResponse(200, response.body.hits, 'Success', null, context);
+
+  } catch (err) {
+    logger.error(JSON.stringify(err)); // Log the error
+    // Send an error response
+    return sendResponse(err?.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+  }
+}

--- a/pdr-api/handlers/parks/_identifier/name/PUT/index.js
+++ b/pdr-api/handlers/parks/_identifier/name/PUT/index.js
@@ -219,6 +219,17 @@ async function createChangeLogItem(body, currentTimeISO, currentRecord, newStatu
   changelogRecord['newEffectiveDate'] = { 'S': body.effectiveDate };
   changelogRecord['newStatus'] = { 'S': newStatus };
   changelogRecord['status'] = { 'S': HISTORICAL_STATE };
+  let legalNameChanged = false;
+  let statusChanged = false;
+  // Mark whether the status and legalName will change for filtering purposes:
+  if (body?.legalName && body?.legalName !== currentRecord.legalName) {
+    legalNameChanged = true;
+  }
+  if (newStatus !== currentRecord.status) {
+    statusChanged = true;
+  }
+  changelogRecord['legalNameChanged'] = { BOOL: legalNameChanged };
+  changelogRecord['statusChanged'] = { BOOL: statusChanged };
 
   return {
     Put: {

--- a/pdr-api/handlers/search/index.js
+++ b/pdr-api/handlers/search/index.js
@@ -21,7 +21,7 @@ exports.handler = async function (event, context) {
     }
 
     // Check if the user is an admin
-    const isAdmin = JSON.parse(event.requestContext?.authorizer?.isAdmin || false);
+    const isAdmin = event?.requestContext?.authorizer?.isAdmin || false;
 
     // Construct the search query
     let query = new OSQuery(OPENSEARCH_MAIN_INDEX, queryParams?.limit, queryParams?.startFrom);
@@ -34,10 +34,10 @@ exports.handler = async function (event, context) {
         delete termQuery[term];
       }
     }
-    query.addMatchTermsRule(termQuery, true);
+    query.addMustMatchTermsRule(termQuery, true);
     // Admin permissions
     if (!isAdmin) {
-      query.addIgnoreTermsRule({ status: 'pending' })
+      query.addMustNotMatchTermsRule({ status: 'pending' })
     }
 
     // Send the query to the OpenSearch cluster

--- a/pdr-api/layers/__tests__/opensearch.test.js
+++ b/pdr-api/layers/__tests__/opensearch.test.js
@@ -126,13 +126,13 @@ describe('OSQuery class', () => {
     });
   });
 
-  describe('addMatchTermsRule method', () => {
+  describe('addMustMatchTermsRule method', () => {
     test('should call addTermsRule correctly', async () => {
       const queryInstance = new OSQuery();
       const terms = { field: 'value' };
       const terms2 = { field2: 'value2', field3: 'value3' };
 
-      queryInstance.addMatchTermsRule(terms, true);
+      queryInstance.addMustMatchTermsRule(terms, true);
 
       expect(queryInstance.query).toEqual({
         bool: {
@@ -144,7 +144,7 @@ describe('OSQuery class', () => {
         },
       });
 
-      queryInstance.addMatchTermsRule(terms2, true);
+      queryInstance.addMustMatchTermsRule(terms2, true);
 
       expect(queryInstance.query).toEqual({
         bool: {
@@ -170,13 +170,13 @@ describe('OSQuery class', () => {
     });
   });
 
-  describe('addIgnoreTermsRule method', () => {
+  describe('addMustNotMatchTermsRule method', () => {
     test('should call addTermsRule correctly with ignore=true and exactMatch=false', async () => {
       const queryInstance = new OSQuery();
       const terms = { field: 'value' };
       const terms2 = { field2: 'value2', field3: 'value3' };
 
-      queryInstance.addIgnoreTermsRule(terms);
+      queryInstance.addMustNotMatchTermsRule(terms);
 
       expect(queryInstance.query).toEqual({
         bool: {
@@ -188,7 +188,7 @@ describe('OSQuery class', () => {
         },
       });
 
-      queryInstance.addIgnoreTermsRule(terms2);
+      queryInstance.addMustNotMatchTermsRule(terms2);
 
       expect(queryInstance.query).toEqual({
         bool: {
@@ -211,6 +211,50 @@ describe('OSQuery class', () => {
           ],
         },
       });
+    });
+  });
+});
+
+describe('addShouldMatchTermsRule method', () => {
+  test('should call addTermsRule correctly with ignore=true and exactMatch=false', async () => {
+    const queryInstance = new OSQuery();
+    const terms = { field: 'value' };
+    const terms2 = { field2: 'value2', field3: 'value3' };
+
+    queryInstance.addShouldMatchTermsRule(terms);
+
+    expect(queryInstance.query).toEqual({
+      bool: {
+        should: [{
+          match: {
+            field: 'value',
+          },
+        }],
+      },
+    });
+
+    queryInstance.addShouldMatchTermsRule(terms2);
+
+    expect(queryInstance.query).toEqual({
+      bool: {
+        should: [
+          {
+            match: {
+              field: 'value',
+            },
+          },
+          {
+            match: {
+              field2: 'value2',
+            },
+          },
+          {
+            match: {
+              field3: 'value3',
+            },
+          },
+        ],
+      },
     });
   });
 });

--- a/pdr-api/postman/Parks Data Register.postman_collection.json
+++ b/pdr-api/postman/Parks Data Register.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "5027d9f1-b4d2-4c08-bdab-a9f29a5af674",
+		"_postman_id": "3029006c-0151-464c-a2dc-b94d16e0281f",
 		"name": "Parks Data Register",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "14509064",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-5027d9f1-b4d2-4c08-bdab-a9f29a5af674?action=share&source=collection_link&creator=14509064"
+		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-3029006c-0151-464c-a2dc-b94d16e0281f?action=share&source=collection_link&creator=14509064"
 	},
 	"item": [
 		{
@@ -50,7 +50,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{vanity_url}}/search?text=park&status=established,historical",
+									"raw": "{{vanity_url}}/search?text=park",
 									"host": [
 										"{{vanity_url}}"
 									],
@@ -59,16 +59,32 @@
 									],
 									"query": [
 										{
+											"key": "type",
+											"value": "protectedArea",
+											"disabled": true
+										},
+										{
+											"key": "startFrom",
+											"value": "4",
+											"disabled": true
+										},
+										{
 											"key": "text",
 											"value": "park"
 										},
 										{
-											"key": "status",
-											"value": "established,historical"
+											"key": "limit",
+											"value": "4",
+											"disabled": true
 										},
 										{
-											"key": "type",
-											"value": "protectedArea",
+											"key": "status",
+											"value": "historical",
+											"disabled": true
+										},
+										{
+											"key": "sortField",
+											"value": "effectiveDate",
 											"disabled": true
 										}
 									]
@@ -173,7 +189,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"legalName\": \"Strathcona Park\",\r\n    \"phoneticName\": \"STRAbthcormba2\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",
+											"raw": "{\r\n    \"effectiveDate\": \"2023-12-01\",\r\n    \"lastVersionDate\": \"2023-12-22T19:09:19.551Z\",\r\n    \"legalName\": \"Strathcona new name\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -219,7 +235,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"legalName\": \"Strathcona Park\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",
+											"raw": "{\r\n    \"lastVersionDate\": \"2023-12-22T19:12:44.725Z\",\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"legalName\": \"Strathcona Park 2\",\r\n    \"displayName\": \"Strathcona \",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Strathcona legal name change\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -265,7 +281,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"legalName\": \"Strathcona Park\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",
+											"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"lastVersionDate\": \"2023-12-22T19:13:33.966Z\",\r\n    \"legalName\": \"Strathcona Park repealed!\",\r\n    \"phoneticName\": \"STRA\",\r\n    \"displayName\": \"Strathcona Park\",\r\n    \"searchTerms\": \"mount asdf\",\r\n    \"notes\": \"Some Notes\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -299,6 +315,69 @@
 									"response": []
 								}
 							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Changelog",
+			"item": [
+				{
+					"name": "Search",
+					"item": [
+						{
+							"name": "Changelog Search",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{vanity_url}}/changelog/search?changeType=legalNameChanged,statusChanged&sortField=updateDate&sortOrder=desc",
+									"host": [
+										"{{vanity_url}}"
+									],
+									"path": [
+										"changelog",
+										"search"
+									],
+									"query": [
+										{
+											"key": "type",
+											"value": "protectedArea",
+											"disabled": true
+										},
+										{
+											"key": "status",
+											"value": "established",
+											"disabled": true
+										},
+										{
+											"key": "text",
+											"value": "park",
+											"disabled": true
+										},
+										{
+											"key": "changeType",
+											"value": "legalNameChanged,statusChanged"
+										},
+										{
+											"key": "sortField",
+											"value": "updateDate"
+										},
+										{
+											"key": "sortOrder",
+											"value": "desc"
+										}
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				}

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -264,6 +264,56 @@ Resources:
               Authorizer: NONE
               OverrideApiAuth: true
 
+  ChangelogSearchFunction:
+    FunctionName: ChangelogSearchFunction
+    Type: AWS::Serverless::Function
+    Properties:
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds:
+          - !Ref SubnetId
+      CodeUri: handlers/changelog/search
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref DynamoDBLayer
+        - !Ref OpenSearchLayer
+      Role: !GetAtt StreamRole.Arn
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 7
+      Description: Changelog Search Handler
+      Policies:
+        - ElasticsearchHttpPostPolicy:
+            DomainName: !Ref DomainName
+      Environment:
+        Variables:
+          LOG_LEVEL: info
+          OPENSEARCH_MAIN_INDEX: !Ref OpenSearchMainIndex
+          OPENSEARCH_DOMAIN_ENDPOINT: !Sub
+            - 'https://${Domain}/'
+            - Domain: !GetAtt OpenSearch.DomainEndpoint
+      Events:
+        ChangelogSearchGet:
+          Type: Api
+          Properties:
+            Path: /changelog/search
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+        ChangelogSearchOptions:
+          Type: Api
+          Properties:
+            Path: /changelog/search
+            Method: OPTIONS
+            RestApiId: !Ref ApiDeployment
+            Auth:
+              ApiKeyRequired: false
+              Authorizer: NONE
+              OverrideApiAuth: true
+
   # Config
   ConfigGet:
     FunctionName: ConfigGet


### PR DESCRIPTION
Relates to #230 
Adds an endpoint `/changelog/search` to provide an easy way for the front end to collect changelog items. The endpoint hits the same `main-index` as the root `/search` function but has some added functionality specific to changelog searches - for example, it hardcodes `status=historical` such that the items the search returns will only be changelog items. 

The endpoint does not necessitate a text search. 

The ticket calls for results to be sorted by system date.

### Get results in reverse chronological order (latest first)
```
GET .../changelog/search?sortField=updateDate&sortOrder=desc
```

### Filter results to include only status changes
```
GET .../changelog/search?changeType=statusChanged
```

### Filter results to include only legal name changes
```
GET .../changelog/search?changeType=legalNameChanged
```

### Filter results to include both status and legal name changes
```
GET .../changelog/search?changeType=legalNameChanged,statusChanged
```