### PR TITLE
PDR-31 view changelog

### DIFF
--- a/pdr-admin/src/app/change-log/change-log.component.html
+++ b/pdr-admin/src/app/change-log/change-log.component.html
@@ -1,1 +1,80 @@
-<div class="container-fluid">Coming soon</div>
+<div class="container-fluid bg-info p-4">
+  <section class="pb-3">
+    <h3>Find changes to legal names and status</h3>
+    <div class="row mb-3">
+      <div class="col">
+        <ngds-text-input
+          class="form-id"
+          [control]="form?.controls?.['text']"
+          [label]="'Search'"
+          [resetButton]="true"
+          [placeholder]="'Enter any search term'"
+          (keyup.enter)="submit()"
+        >
+          <button ngdsInputAppend class="btn btn-primary" (click)="submit()" [disabled]="loading || form.invalid">
+            <ng-container *ngIf="!loading"> <i class="bi bi-search me-2"></i>Search</ng-container>
+            <ng-container *ngIf="loading">
+              <div class="spinner-border spinner-border-sm" role="status">
+                <span class="visually-hidden">Loading...</span>
+              </div>
+            </ng-container>
+          </button>
+        </ngds-text-input>
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-12 col-md-6">
+        <strong>Filters</strong>
+        <div class="row">
+          <div class="col-auto">
+            <ngds-toggle-input [control]="form?.controls?.['legalNameToggle']" [label]="'Legal Name'">
+            </ngds-toggle-input>
+          </div>
+          <div class="col-auto">
+            <ngds-toggle-input [control]="form?.controls?.['statusToggle']" [label]="'Status'"> </ngds-toggle-input>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="container-fluid p-4">
+  <h3>Search results</h3>
+  <table class="table table-striped mb-0" aria-label="Name search results">
+    <thead>
+      <tr>
+        <th scope="col" colspan="1">DATE OF CHANGE</th>
+        <th scope="col" colspan="1">ID</th>
+        <th scope="col" colspan="1">FIELD CHANGED</th>
+        <th scope="col">PREVIOUS VALUE</th>
+        <th scope="col">UPDATED VALUE</th>
+        <th scope="col" colspan="1">CHANGED BY</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let item of data">
+        <th class="py-3" scope="row" colspan="1">{{ item.displayId }}</th>
+        <td class="py-3">
+          <strong>{{ item.legalName }}</strong>
+        </td>
+        <td class="py-3">{{ this.utils.upperCaseFirstChar(item.status) }}</td>
+        <td class="action-column" colspan="1">
+          <div class="d-flex">
+            <i class="bi bi-eye me-4" (click)="viewItem(item)"></i>
+            <i class="bi bi-pen-fill" (click)="editItem(item)"></i>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div *ngIf="data.length === 0" class="table-stripe-dark py-3 ps-2 border-bottom">No results. Try a new search.</div>
+  <div *ngIf="!searchParams.lastPage && data.length > 0" class="d-flex justify-content-center py-3">
+    <button class="btn btn-outline-secondary" [disabled]="loading" (click)="loadMore()">
+      <div *ngIf="!loading">Load More</div>
+      <div *ngIf="loading" class="spinner-border spinner-border-sm mx-4" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </button>
+  </div>
+</div>

--- a/pdr-admin/src/app/change-log/change-log.component.html
+++ b/pdr-admin/src/app/change-log/change-log.component.html
@@ -10,8 +10,9 @@
           [resetButton]="true"
           [placeholder]="'Enter any search term'"
           (keyup.enter)="submit()"
+          [loadWhile]="loading"
         >
-          <button ngdsInputAppend class="btn btn-primary" (click)="submit()" [disabled]="loading || form.invalid">
+          <button ngdsInputAppend class="btn btn-primary" (click)="submit()" [disabled]="form.invalid">
             <ng-container *ngIf="!loading"> <i class="bi bi-search me-2"></i>Search</ng-container>
             <ng-container *ngIf="loading">
               <div class="spinner-border spinner-border-sm" role="status">
@@ -28,11 +29,11 @@
         <strong>Filters</strong>
         <div class="row">
           <div class="col-auto">
-            <ngds-toggle-input [control]="form?.controls?.['legalNameToggle']" [label]="'Legal Name'">
+            <ngds-toggle-input [control]="form?.controls?.['legalNameChanged']" [label]="'Legal Name'" [loadWhile]="loading">
             </ngds-toggle-input>
           </div>
           <div class="col-auto">
-            <ngds-toggle-input [control]="form?.controls?.['statusToggle']" [label]="'Status'"> </ngds-toggle-input>
+            <ngds-toggle-input [control]="form?.controls?.['statusChanged']" [label]="'Status'" [loadWhile]="loading"> </ngds-toggle-input>
           </div>
         </div>
       </div>
@@ -54,21 +55,27 @@
     </thead>
     <tbody>
       <tr *ngFor="let item of data">
-        <th class="py-3" scope="row" colspan="1">{{ item.displayId }}</th>
+        <th class="py-3" scope="row" colspan="1">{{ item?.updateDate | date}}</th>
         <td class="py-3">
-          <strong>{{ item.legalName }}</strong>
+          <strong>{{ item?.displayId }}</strong>
         </td>
-        <td class="py-3">{{ this.utils.upperCaseFirstChar(item.status) }}</td>
-        <td class="action-column" colspan="1">
-          <div class="d-flex">
-            <i class="bi bi-eye me-4" (click)="viewItem(item)"></i>
-            <i class="bi bi-pen-fill" (click)="editItem(item)"></i>
-          </div>
-        </td>
+        <td class="py-3">{{ getChangeTypeString(item) }}</td>
+        <td class="py-3">{{ getOldFieldString(item) }}</td>
+        <td class="py-3">{{ getNewFieldString(item) }}</td>
+        <td class="py-3">{{ item?.lastModifiedBy || '-' }}</td>
       </tr>
     </tbody>
   </table>
-  <div *ngIf="data.length === 0" class="table-stripe-dark py-3 ps-2 border-bottom">No results. Try a new search.</div>
+  <div *ngIf="data.length === 0" class="table-stripe-dark py-3 ps-2 border-bottom d-flex justify-content-center">
+    <div *ngIf="!loading">
+      No results. Try a new search.
+    </div>
+    <div *ngIf="loading">
+      <div class="spinner-border spinner-border-sm" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+  </div>
   <div *ngIf="!searchParams.lastPage && data.length > 0" class="d-flex justify-content-center py-3">
     <button class="btn btn-outline-secondary" [disabled]="loading" (click)="loadMore()">
       <div *ngIf="!loading">Load More</div>

--- a/pdr-admin/src/app/change-log/change-log.component.scss
+++ b/pdr-admin/src/app/change-log/change-log.component.scss
@@ -1,0 +1,34 @@
+@import "@digitalspace/bcparks-bootstrap-theme/dist/scss/variables";
+
+$table-stripe-dark: #f2f2f2;
+
+.white-divider {
+  background-color: white;
+  height: 3px;
+}
+
+.table-stripe-dark {
+  background-color: $table-stripe-dark;
+}
+
+.audio-column {
+  padding-top: 0.7rem;
+  i {
+    font-size: 1.25rem;
+  }
+}
+
+.action-column {
+  padding-top: 0.7rem;
+  i {
+    color: #326eaa;
+    font-size: 1.25rem;
+  }
+  i:hover {
+    cursor: pointer;
+  }
+}
+
+.pointer {
+  cursor: default !important;
+}

--- a/pdr-admin/src/app/change-log/change-log.component.spec.ts
+++ b/pdr-admin/src/app/change-log/change-log.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChangeLogComponent } from './change-log.component';
+import { ConfigService } from '../services/config.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ToastrModule } from 'ngx-toastr';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 
 describe('ChangeLogComponent', () => {
   let component: ChangeLogComponent;
@@ -8,7 +13,11 @@ describe('ChangeLogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ChangeLogComponent]
+      declarations: [ChangeLogComponent],
+      imports: [HttpClientTestingModule, RouterTestingModule, ToastrModule.forRoot({}), NgdsFormsModule ],
+      providers: [
+        ConfigService,
+      ]
     });
     fixture = TestBed.createComponent(ChangeLogComponent);
     component = fixture.componentInstance;

--- a/pdr-admin/src/app/change-log/change-log.component.ts
+++ b/pdr-admin/src/app/change-log/change-log.component.ts
@@ -1,10 +1,174 @@
-import { Component } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { LoadingService } from '../services/loading.service';
+import { LoggerService } from '../services/logger.service';
+import { ProtectedAreaService } from '../services/protected-area.service';
+import { SearchService } from '../services/search.service';
+import { UrlService } from '../services/url.service';
+import { Utils } from '../utils/utils';
 
 @Component({
   selector: 'app-change-log',
   templateUrl: './change-log.component.html',
-  styleUrls: ['./change-log.component.scss']
+  styleUrls: ['./change-log.component.scss'],
 })
 export class ChangeLogComponent {
+  private subscriptions = new Subscription();
 
+  // TODO: This will be a switch for all searches. (protectedArea, sites, etc)
+  private searchType = 'protectedArea';
+
+  public toggleList = ['established', 'repealed', 'pending'];
+
+  public utils = new Utils();
+  loading = false;
+  data = [];
+  form = new UntypedFormGroup({
+    text: new UntypedFormControl(null, { nonNullable: true, validators: [Validators.required] }),
+    type: new UntypedFormControl(null),
+    legalNameToggle: new UntypedFormControl(false),
+    statusToggle: new UntypedFormControl(false),
+  });
+
+  public searchParams = {
+    lastResultIndex: null,
+    lastPage: true,
+  };
+
+  constructor(
+    private router: Router,
+    private searchService: SearchService,
+    private protectedAreaService: ProtectedAreaService,
+    private loadingService: LoadingService,
+    private ref: ChangeDetectorRef,
+    private urlService: UrlService,
+    private logger: LoggerService
+  ) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.searchService.watchSearchResults().subscribe((res) => {
+        this.data = res && res.data ? res.data : [];
+        this.searchParams =
+          res && res.searchParams
+            ? res.searchParams
+            : {
+                lastResultIndex: null,
+                lastPage: true,
+              };
+        this.ref.detectChanges();
+      })
+    );
+    this.subscriptions.add(
+      this.loadingService.getLoadingStatus().subscribe((res) => {
+        this.loading = res;
+        this.ref.detectChanges();
+      })
+    );
+    this.subscriptions.add(
+      this.form.valueChanges.subscribe((changes) => {
+        this.ref.detectChanges();
+      })
+    );
+    this.checkForQueryParams();
+  }
+
+  checkForQueryParams() {
+    // Get query params and set form values accordingly
+    let params = { ...this.urlService.getQueryParams() };
+    if (Object.keys(params).length) {
+      params = this.setStatusFilters(params);
+      for (const param in params) {
+        if (this.form.controls[param]) {
+          this.form.controls[param].setValue(params[param]);
+        }
+      }
+      // Check cache.
+      const url = this.urlService.getRoute();
+      const cache = this.searchService.checkCache(url);
+      if (cache) {
+        // Cache hit.
+        this.logger.debug(`Cache hit: ${url}`);
+        this.searchService.setSearchResults(cache);
+      } else {
+        this.logger.debug(`Cache miss or expiry: ${url}`);
+        this.submit(false);
+      }
+    }
+  }
+
+  async submit(updateQueryParams = true, startFrom = 0) {
+    if (this.form.valid) {
+      this.form.controls['type'].setValue(this.searchType);
+      // If none of the status toggles are true, this is equivalent to all of them being true.
+      // This will create divergent behaviour between the URL and the actual search payload.
+      const searchObj = this.getStatusFilters({ ...this.form.value });
+      const urlObj = this.getStatusFilters({ ...this.form.value }, false);
+      if (updateQueryParams) {
+        // update url query params
+        delete urlObj.type;
+        // await this change before
+        await this.urlService.setQueryParams(urlObj);
+      }
+      this.searchService.fetchData(searchObj, this.urlService.getRoute(), startFrom);
+    }
+  }
+
+  getStatusFilters(obj, persistToggles = true) {
+    let filters = [];
+
+    this.toggleList.forEach((toggle) => {
+      if (obj[`${toggle}Toggle`] === true) {
+        filters.push(toggle);
+      }
+      delete obj[`${toggle}Toggle`];
+    });
+
+    obj.status = filters.length > 0 ? filters.toString() : persistToggles ? this.toggleList.toString() : '';
+    return obj;
+  }
+
+  setStatusFilters(obj) {
+    const statuses = obj?.status?.split(',');
+    if (!statuses) {
+      return obj;
+    }
+    for (const toggle of this.toggleList) {
+      if (statuses.indexOf(toggle) > -1) {
+        obj[`${toggle}Toggle`] = true;
+      }
+    }
+    delete obj?.status;
+    return obj;
+  }
+
+  viewItem(item) {
+    if (item.type === 'protectedArea') {
+      this.protectedAreaService.fetchData(item.pk);
+      // TODO: When we have historical park names, we want to set HISTORICAL_PROTECTED_AREA here.
+      this.router.navigate(['protected-areas', item.pk]);
+    }
+  }
+
+  editItem(item) {
+    if (item.type === 'protectedArea') {
+      this.protectedAreaService.fetchData(item.pk);
+      if (item.status === 'repealed') {
+        this.router.navigate(['protected-areas', item.pk, 'edit-repealed']);
+      } else {
+        this.router.navigate(['protected-areas', item.pk, 'edit']);
+      }
+    }
+  }
+
+  loadMore() {
+    this.submit(false, this.searchParams.lastResultIndex);
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+    this.searchService.clearSearchResults();
+  }
 }

--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
@@ -88,7 +88,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
       }
       // Check cache.
       const url = this.urlService.getRoute();
-      const cache = this.searchService.checkCache(url);
+      const cache = this.urlService.checkCache(url);
       if (cache) {
         // Cache hit.
         this.logger.debug(`Cache hit: ${url}`);

--- a/pdr-admin/src/app/services/changelog.service.spec.ts
+++ b/pdr-admin/src/app/services/changelog.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ChangelogService } from './changelog.service';
+import { ConfigService } from './config.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ToastrModule } from 'ngx-toastr';
+
+describe('ChangelogService', () => {
+  let service: ChangelogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, ToastrModule.forRoot({})],
+      providers: [
+        ConfigService,
+      ]
+    });
+    service = TestBed.inject(ChangelogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/pdr-admin/src/app/services/changelog.service.ts
+++ b/pdr-admin/src/app/services/changelog.service.ts
@@ -1,45 +1,39 @@
 import { Injectable } from '@angular/core';
-import { DataService } from './data.service';
-import { Constants } from '../utils/constants';
-import { ApiService } from './api.service';
-import { lastValueFrom } from 'rxjs';
 import { LoadingService } from './loading.service';
+import { Constants } from '../utils/constants';
+import { lastValueFrom } from 'rxjs';
+import { ApiService } from './api.service';
 import { LoggerService } from './logger.service';
-import { ToastService, ToastTypes } from './toast.service';
 import { EventKeywords, EventObject, EventService } from './event.service';
+import { ToastService, ToastTypes } from './toast.service';
 import { Utils } from '../utils/utils';
+import { DataService } from './data.service';
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
-export class SearchService {
+export class ChangelogService {
   private utils = new Utils();
-
   public pageSize = 20;
 
   constructor(
     private dataService: DataService,
-    private apiService: ApiService,
     private loadingService: LoadingService,
+    private apiService: ApiService,
     private loggerService: LoggerService,
-    private toastService: ToastService,
-    private eventService: EventService
-  ) {}
+    private eventService: EventService,
+    private toastService: ToastService
+  ) { }
 
   async fetchData(queryParams, cacheUrl = null, startFrom = 0) {
-    this.loadingService.addToFetchList(Constants.dataIds.SEARCH_RESULTS);
-    // Calling API with status = null gives you current and historical
+    this.loadingService.addToFetchList(Constants.dataIds.CHANGELOG_SEARCH_RESULTS);
     try {
-      // Start from a certain value if provided
       queryParams['startFrom'] = startFrom;
-      // Add 1 to the result limit. If the number of results returned is equal to this additional limit, we know there is at least 1 more page of results to query.
       let lastPage = true;
       queryParams['limit'] = this.pageSize + 1;
-      const res = await lastValueFrom(this.apiService.get('search', queryParams));
+      const res = await lastValueFrom(this.apiService.get('changelog/search', queryParams));
       let data = this.apiService.getArrayFromSearchResults(res);
       if (data.length >= this.pageSize + 1) {
-        // We know theres more pages of results because we were able to bring in more than the page size.
-        // Remove the last result
         data.pop();
         lastPage = false;
       }
@@ -50,18 +44,17 @@ export class SearchService {
       const searchParams = {
         lastPage: lastPage,
         lastResultIndex: lastResultIndex,
-        lastQuery: queryParams,
-      };
-
+        lastQuery: queryParams
+      }
       // Get previous results array if it exists and concat new data to the end of it
-      if (this.dataService.getItemValue(Constants.dataIds.SEARCH_RESULTS)?.data)
-        data = this.dataService.getItemValue(Constants.dataIds.SEARCH_RESULTS).data.concat(data);
-      this.dataService.setItemValue(Constants.dataIds.SEARCH_RESULTS, {
+      if (this.dataService.getItemValue(Constants.dataIds.CHANGELOG_SEARCH_RESULTS)?.data)
+        data = this.dataService.getItemValue(Constants.dataIds.CHANGELOG_SEARCH_RESULTS).data.concat(data);
+      this.dataService.setItemValue(Constants.dataIds.CHANGELOG_SEARCH_RESULTS, {
         data: data,
         searchParams: searchParams,
       });
       if (cacheUrl) {
-        this.dataService.setCacheValue(cacheUrl, this.dataService.getItemValue(Constants.dataIds.SEARCH_RESULTS), 300);
+        this.dataService.setCacheValue(cacheUrl, this.dataService.getItemValue(Constants.dataIds.CHANGELOG_SEARCH_RESULTS), 300);
         this.loggerService.debug(`Cache update ${cacheUrl}`);
       }
     } catch (e) {
@@ -69,18 +62,19 @@ export class SearchService {
       this.toastService.addMessage(`Something went wrong. Please try again.`, ``, ToastTypes.ERROR);
       this.eventService.setError(new EventObject(EventKeywords.ERROR, String(e), 'Park Service'));
     }
-    this.loadingService.removeFromFetchList(Constants.dataIds.SEARCH_RESULTS);
+    this.loadingService.removeFromFetchList(Constants.dataIds.CHANGELOG_SEARCH_RESULTS);
   }
 
-  watchSearchResults() {
-    return this.dataService.watchItem(Constants.dataIds.SEARCH_RESULTS);
+  watchChangelogResults() {
+    return this.dataService.watchItem(Constants.dataIds.CHANGELOG_SEARCH_RESULTS);
   }
 
-  clearSearchResults() {
-    return this.dataService.clearItemValue(Constants.dataIds.SEARCH_RESULTS);
+  clearChangelogResults() {
+    return this.dataService.clearItemValue(Constants.dataIds.CHANGELOG_SEARCH_RESULTS);
   }
 
   setSearchResults(data) {
     this.dataService.setItemValue(Constants.dataIds.SEARCH_RESULTS, data);
   }
+
 }

--- a/pdr-admin/src/app/services/url.service.ts
+++ b/pdr-admin/src/app/services/url.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
+import { DataService } from './data.service';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,8 @@ export class UrlService implements OnDestroy {
 
   constructor(
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private dataService: DataService
   ) {
     this.route.queryParams.subscribe((changes) => {
       this.queryParams.next(changes);
@@ -58,6 +60,10 @@ export class UrlService implements OnDestroy {
       replaceUrl: true
     })
 
+  }
+
+  checkCache(url) {
+    return this.dataService.getCachedValue(url);
   }
 
   ngOnDestroy() {

--- a/pdr-admin/src/app/utils/constants.ts
+++ b/pdr-admin/src/app/utils/constants.ts
@@ -5,6 +5,7 @@ export class Constants {
     CURRENT_PROTECTED_AREA: 'current-protected-area',
     PROTECTED_AREA_PUT: 'protected-area-put',
     HISTORICAL_PROTECTED_AREA: 'historical-protected-area',
+    CHANGELOG_SEARCH_RESULTS: 'changelog-search-results'
   };
 
   public static readonly timeZoneIANA = 'America/Vancouver';


### PR DESCRIPTION
Completes #31

This change adds a changelog search to the front end. As per the ticket, the first 20 results are loaded in descending chronological order when landing on the page. Filtering by text or by statusChanged or legalNameChanged is also possible.

Note that only changelog items that have been created after #318 was merged will have the correct structure to appear properly in the changelog search. If there are existing changelog items that should be shown, we should create a new ticket to migrate them to the proper format.