### PR TITLE
PDR-329 Clear search results when performing a new test

### DIFF
--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.ts
@@ -100,7 +100,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
     }
   }
 
-  async submit(updateQueryParams = true, startFrom = 0) {
+  async submit(updateQueryParams = true, startFrom = 0, clearExisting = true) {
     if (this.form.valid) {
       this.form.controls['type'].setValue(this.searchType);
       // If none of the status toggles are true, this is equivalent to all of them being true.
@@ -112,6 +112,9 @@ export class ProtectedAreaSearchComponent implements OnInit {
         delete urlObj.type;
         // await this change before
         await this.urlService.setQueryParams(urlObj);
+      }
+      if (clearExisting) {
+        this.searchService.clearSearchResults();
       }
       this.searchService.fetchData(searchObj, this.urlService.getRoute(), startFrom);
     }
@@ -165,7 +168,7 @@ export class ProtectedAreaSearchComponent implements OnInit {
   }
 
   loadMore() {
-    this.submit(false, this.searchParams.lastResultIndex);
+    this.submit(false, this.searchParams.lastResultIndex, false);
   }
 
   ngOnDestroy() {

--- a/pdr-admin/src/app/utils/utils.spec.ts
+++ b/pdr-admin/src/app/utils/utils.spec.ts
@@ -22,7 +22,7 @@ describe('Utils', () => {
   });
 
   it('should format date for display: success', () => {
-    const date = new Date(1989, 3, 5);
+    const date = new Date("1989-04-05T12:00:00.000+08:00");
     const res = utils.formatDateForDisplay(date);
     expect(res).toEqual('April 04, 1989');
   });
@@ -65,7 +65,7 @@ describe('Utils', () => {
   });
 
   it('should set display date', () => {
-    const obj = { hotdog: new Date(1989, 3, 5) };
+    const obj = { hotdog: new Date("1989-04-05T12:00:00.000+08:00") };
     const res = utils.setDisplayDate(obj, 'hotdog');
     expect(res.hotdogDisplay).toEqual('April 04, 1989');
   });


### PR DESCRIPTION
Fixes #329.

Search results were being appended to existing results. Now when the search button is clicked, the previous search is wiped and a new search is performed. If the load more button is clicked, the results are still appended.

Also fixed some unit tests that were failing due to timezone differences.