### PR TITLE
332: Adding get for park site objs.

### DIFF
--- a/pdr-api/__tests__/mock_data.js
+++ b/pdr-api/__tests__/mock_data.js
@@ -12,7 +12,7 @@ exports.MockData = class {
     legalName: 'Test Park 1',
     displayName: 'Test Park 1',
     phoneticName: 'tɛst pɑːk wʌn',
-    status: 'current',
+    status: 'established',
     notes: 'some notes'
   };
   mockOldParkName1 = {
@@ -21,7 +21,7 @@ exports.MockData = class {
     legalName: 'Old Park 1',
     displayName: 'Old Park 1',
     phoneticName: 'əʊld pɑːk wʌn',
-    status: 'old',
+    status: 'historical',
     notes: 'some notes'
   };
   mockCurrentParkName2 = {
@@ -32,8 +32,67 @@ exports.MockData = class {
     legalName: 'Test Park 2',
     displayName: 'Test Park 2',
     phoneticName: 'tɛst pɑːk tuː',
-    status: 'current',
+    status: 'established',
     notes: 'some notes'
+  };
+  mockPendingParkName1 = {
+    pk: '3',
+    sk: 'Details',
+    createDate: '2023-08-10T16:11:54.513Z',
+    updateDate: '2023-08-10T16:11:54.513Z',
+    legalName: 'Test Park 3',
+    displayName: 'Test Park 3',
+    phoneticName: 'tɛst pɑːk 3',
+    status: 'pending',
+    notes: 'some notes'
+  };
+  mockParkSite1 = {
+    pk: '1',
+    sk: 'Site::1',
+    displayName: 'Test Site 1-1',
+  };
+  mockParkSite2 = {
+    pk: '3',
+    sk: 'Site::1',
+    displayName: 'Test Site 3-1',
+  };
+  mockCurrentSite1 = {
+    pk: '1::Site::1',
+    sk: 'Details',
+    createDate: '2023-08-10T16:11:54.513Z',
+    updateDate: '2023-08-10T16:11:54.513Z',
+    legalName: 'Test Site 1-1',
+    displayName: 'Test Site 1-1',
+    phoneticName: 'tɛst site wʌn',
+    status: 'established',
+    lastModifiedBy: 'TESTADMIN',
+    type: 'site'
+  };
+  mockOldSite1 = {
+    pk: '1::Site::1',
+    sk: '2019-08-10T16:15:50.868Z',
+    legalName: 'Old Site 1-1',
+    displayName: 'Old Site 1-1',
+    phoneticName: 'əʊld site wʌn',
+    status: 'historical',
+    lastModifiedBy: 'TESTADMIN',
+    newLegalName: 'Test Site 1-1',
+    newEffectiveDate: '2020-08-10T16:15:50.868Z',
+    displayId: '0001-1',
+    legalNameChanged: 'true',
+    statusChanged: 'false'
+  };
+  mockCurrentSite2 = {
+    pk: '3::Site::1',
+    sk: 'Details',
+    createDate: '2023-08-10T16:11:54.513Z',
+    updateDate: '2023-08-10T16:11:54.513Z',
+    legalName: 'Test Site 3-1',
+    displayName: 'Test Site 3-1',
+    phoneticName: 'tɛst site wʌn',
+    status: 'established',
+    lastModifiedBy: 'TESTADMIN',
+    type: 'site'
   };
 
   allData = () => {
@@ -41,7 +100,13 @@ exports.MockData = class {
       this.mockConfig,
       this.mockCurrentParkName1,
       this.mockCurrentParkName2,
-      this.mockOldParkName1
+      this.mockOldParkName1,
+      this.mockPendingParkName1,
+      this.mockParkSite1,
+      this.mockParkSite2,
+      this.mockCurrentSite1,
+      this.mockOldSite1,
+      this.mockCurrentSite2
     ]
   }
 }

--- a/pdr-api/handlers/parks/_identifier/name/__tests__/get.test.js
+++ b/pdr-api/handlers/parks/_identifier/name/__tests__/get.test.js
@@ -47,7 +47,7 @@ describe('Specific Park Names GET', () => {
     const res = await lambda.handler(event, null);
     const body = JSON.parse(res.body);
     expect(res.statusCode).toBe(200);
-    expect(body.data.items.length).toBe(2);
+    expect(body.data.items.length).toBe(3);
   });
 
   test('Get all current name information for park identifier', async () => {
@@ -55,7 +55,7 @@ describe('Specific Park Names GET', () => {
     const event = {
       httpMethod: 'GET',
       queryStringParameters: {
-        status: 'current'
+        status: 'established'
       },
       pathParameters: {
         identifier: '1'
@@ -70,7 +70,7 @@ describe('Specific Park Names GET', () => {
     const body = JSON.parse(res.body);
     expect(res.statusCode).toBe(200);
     expect(body.data.items.length).toBe(1);
-    expect(body.data.items[0].status).toEqual('current');
+    expect(body.data.items[0].status).toEqual('established');
   });
 
   test('Public user', async () => {

--- a/pdr-api/handlers/parks/_identifier/sites/GET/index.js
+++ b/pdr-api/handlers/parks/_identifier/sites/GET/index.js
@@ -1,0 +1,50 @@
+const { runQuery, TABLE_NAME, getOne } = require('/opt/dynamodb');
+const { sendResponse, logger } = require('/opt/base');
+
+exports.handler = async (event, context) => {
+    logger.debug('Get list of sites for a protected area', event);
+    // Allow CORS
+    if (event.httpMethod === 'OPTIONS') {
+        return sendResponse(200, {}, 'Success', null, context);
+    }
+
+    try {
+        const identifier = event.pathParameters.identifier;
+        const isAdmin = JSON.parse(event.requestContext?.authorizer?.isAdmin || false);
+
+        // Check if query is valid
+        await validateRequest(identifier, isAdmin);
+
+        // SK for PA Site obj is Site::{siteId}
+        let query = {
+            TableName: TABLE_NAME,
+            ExpressionAttributeValues: {
+                ':pk': { S: identifier },
+                ':beginsWith': { S: 'Site::' }
+            },
+            KeyConditionExpression: 'pk = :pk and begins_with(sk, :beginsWith)',
+        };
+        const res = await runQuery(query);
+
+        logger.debug('Get list of sites for a protected area result', res);
+
+        return sendResponse(200, res, 'Success', null, context);
+    } catch (err) {
+        logger.error(err);
+        return sendResponse(err?.code || 400, [], err?.msg || 'Error', err?.error || err, context);
+    }
+};
+
+async function validateRequest(identifier, isAdmin) {
+    // Public users are not allowed to see sites that are part of a pending protected area
+    let protectedArea = null;
+    try {
+        protectedArea = await getOne(identifier, 'Details');
+    } catch (err) {
+        logger.Error('err:', err)
+        throw new Error('Error getting protected area');
+    }
+    if (!isAdmin && protectedArea?.status === 'pending') {
+        throw new Error('Not authorized');
+    }
+}

--- a/pdr-api/handlers/parks/_identifier/sites/__tests__/get.test.js
+++ b/pdr-api/handlers/parks/_identifier/sites/__tests__/get.test.js
@@ -1,0 +1,56 @@
+const { createDB } = require('../../../../../__tests__/settings');
+const { MockData } = require('../../../../../__tests__/mock_data');
+
+const data = new MockData;
+let dbClient;
+
+describe('Specific Park Names GET', () => {
+    const OLD_ENV = process.env;
+    beforeEach(async () => {
+        jest.resetModules();
+        dbClient = await createDB(data.allData());
+        process.env = { ...OLD_ENV }; // Make a copy of environment
+    });
+
+    afterAll(() => {
+        process.env = OLD_ENV; // Restore old environment
+    });
+
+    test('Get all sites for park identifier', async () => {
+        const lambda = require('../GET/index');
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                identifier: '1'
+            },
+            requestContext: {
+                authorizer: {
+                    isAdmin: true
+                }
+            }
+        }
+        const res = await lambda.handler(event, null);
+        const body = JSON.parse(res.body);
+        expect(res.statusCode).toBe(200);
+        expect(body.data.items.length).toBe(1);
+    });
+
+
+    test('Get all sites for park identifier as a public user', async () => {
+        const lambda = require('../GET/index');
+        const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+                identifier: '3'
+            },
+            requestContext: {
+                authorizer: {
+                    isAdmin: false
+                }
+            }
+        }
+        // public not allowed to see status = pending
+        const res = await lambda.handler(event, null);
+        expect(res.statusCode).toBe(400);
+    });
+});

--- a/pdr-api/handlers/parks/names/__tests__/get.test.js
+++ b/pdr-api/handlers/parks/names/__tests__/get.test.js
@@ -46,7 +46,7 @@ describe('All Park Names GET', () => {
     const event = {
       httpMethod: 'GET',
       queryStringParameters: {
-        status: 'current'
+        status: 'established'
       },
       requestContext: {
         authorizer: {
@@ -57,7 +57,7 @@ describe('All Park Names GET', () => {
     const res = await lambda.handler(event, null);
     const body = JSON.parse(res.body);
     expect(res.statusCode).toBe(200);
-    expect(body.data.items.length).toBe(2);
+    expect(body.data.items.length).toBe(4);
   });
 
   test('Search all park names by legal name', async () => {
@@ -86,7 +86,7 @@ describe('All Park Names GET', () => {
       httpMethod: 'GET',
       queryStringParameters: {
         legalName: 'Old Park 1',
-        status: 'current'
+        status: 'established'
       },
       requestContext: {
         authorizer: {
@@ -98,7 +98,7 @@ describe('All Park Names GET', () => {
       httpMethod: 'GET',
       queryStringParameters: {
         legalName: 'Test Park 1',
-        status: 'current'
+        status: 'established'
       },
       requestContext: {
         authorizer: {

--- a/pdr-api/layers/__tests__/dynamodb.test.js
+++ b/pdr-api/layers/__tests__/dynamodb.test.js
@@ -85,11 +85,12 @@ describe('DynamoDB Layer Tests', () => {
     const regScan = await layer.runScan(scan);
     expect(regScan.items).toEqual(expect.arrayContaining([
       data.mockCurrentParkName1,
-      data.mockOldParkName1
+      data.mockOldParkName1,
+      data.mockParkSite1
     ]));
 
     // Limited scan
-    const limitScan = await layer.runScan(scan, 1);
+    const limitScan = await layer.runScan(scan, 3);
     expect(limitScan.items.length).toEqual(1);
     expect(limitScan).toHaveProperty('lastEvaluatedKey');
 

--- a/pdr-api/migrations/2024-02-29_updateSiteObj.js
+++ b/pdr-api/migrations/2024-02-29_updateSiteObj.js
@@ -1,0 +1,63 @@
+const AWS = require('aws-sdk');
+const TABLE_NAME = process.env.TABLE_NAME || 'NameRegister';
+const { updateConsoleProgress, finishConsoleUpdates, errorConsoleUpdates } = require('../tools/progressIndicator');
+
+/*
+  This migration adds sites to the database
+*/
+
+const options = {
+    region: 'ca-central-1'
+};
+
+if (process.env.IS_OFFLINE === 'true') {
+    options.endpoint = process.env.DYNAMODB_ENDPOINT_URL || 'http://localhost:8000';
+}
+
+const dynamodb = new AWS.DynamoDB(options);
+
+async function run() {
+    try {
+        let count = 0;
+        let startTime = new Date();
+
+        const scan = {
+            TableName: TABLE_NAME,
+            ExpressionAttributeValues: {
+                ':beginsWith': { S: 'Site::' }
+            },
+            FilterExpression: 'begins_with(sk, :beginsWith)'
+        }
+        const rows = await dynamodb.scan(scan).promise();
+        for (const row of rows.Items) {
+            // Get site obj
+            const getItem = {
+                TableName: TABLE_NAME,
+                Key: { pk: { S: `${row.pk.S}::${row.sk.S}` }, sk: { S: 'Details' } }
+            };
+            const site = await dynamodb.getItem(getItem).promise();
+
+            // Update site entry
+            const updateParams = {
+                TableName: TABLE_NAME,
+                Key: {
+                    pk: row.pk,
+                    sk: row.sk
+                },
+                ExpressionAttributeValues: {
+                    ':displayName': site.Item.displayName
+                },
+                UpdateExpression: 'SET displayName = :displayName',
+                ReturnValues: 'ALL_NEW'
+            }
+            count++;
+            updateConsoleProgress(startTime, 'Batch writing items', 1, count, rows.length);
+            await dynamodb.updateItem(updateParams).promise();
+        }
+        finishConsoleUpdates();
+    } catch (err) {
+        errorConsoleUpdates(err);
+    }
+}
+
+run();

--- a/pdr-api/postman/Parks Data Register.postman_collection.json
+++ b/pdr-api/postman/Parks Data Register.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "3029006c-0151-464c-a2dc-b94d16e0281f",
+		"_postman_id": "5e8ff27b-5007-49ec-9d94-0646c0155f1b",
 		"name": "Parks Data Register",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14509064",
-		"_collection_link": "https://bcparks-dup.postman.co/workspace/BCParks-Day-Use-Pass~c6a232b9-cbde-4bc3-aa2c-906ab8c015e7/collection/14509064-3029006c-0151-464c-a2dc-b94d16e0281f?action=share&source=collection_link&creator=14509064"
+		"_exporter_id": "21509305"
 	},
 	"item": [
 		{
@@ -308,6 +307,36 @@
 												{
 													"key": "identifier",
 													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Sites",
+							"item": [
+								{
+									"name": "Get Sites By Park Id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{base_url}}/parks/:identifier/sites",
+											"host": [
+												"{{base_url}}"
+											],
+											"path": [
+												"parks",
+												":identifier",
+												"sites"
+											],
+											"variable": [
+												{
+													"key": "identifier",
+													"value": "300"
 												}
 											]
 										}

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -635,6 +635,48 @@ Resources:
         PointInTimeRecoveryEnabled: true
     DependsOn: NameRegister
 
+  # Get sites by park id
+  SitesByParkIdGet:
+    FunctionName: SitesByParkIdGet
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/parks/_identifier/sites/GET
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref DynamoDBLayer
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Sites by Park Id GET lambda function
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref TableNameRegister
+          LOG_LEVEL: info
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableNameRegister
+      Events:
+        SitesByParkIdGet:
+          Type: Api
+          Properties:
+            Path: /parks/{identifier}/sites
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+        SitesByParkIdOptions:
+          Type: Api
+          Properties:
+            Path: /parks/{identifier}/sites
+            Method: OPTIONS
+            RestApiId: !Ref ApiDeployment
+            Auth:
+              ApiKeyRequired: false
+              Authorizer: NONE
+              OverrideApiAuth: true
+
+
 Outputs:
   #   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   #   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
One of many PRs for:
https://github.com/bcgov/parks-data-register/issues/332

- Adding endpoint to get park site objects
- Migration added to include display name on park site objects
- Tests updated
- Postman updated
- SAM template updated