### PR TITLE
PDR-412 FE updates for PAs

### DIFF
--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.html
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.html
@@ -1,11 +1,18 @@
 <section>
-  <h1 *ngIf="updateType === 'minor'">Make Minor edits</h1>
-  <h1 *ngIf="updateType === 'major'">Change legal name</h1>
-  <h2>Required data</h2>
-  <p *ngIf="updateType === 'major'">
-    After you enter a new legal name, the name currently in use and all its associated data will be automatically placed
-    under historical names.
-  </p>
+  <div *ngIf="updateType === 'minor'">
+    <h1 class="mb-3">Make minor edits</h1>
+    <p>
+      Use only for minor changes like typos or to add missing information. If editing a repealed record only the effective date may be updated.
+    </p>
+  </div>
+  <div *ngIf="updateType === 'major'">
+    <h1 class="mb-3">Change legal name</h1>
+    <p>
+      After you enter a new legal name, the name currently in use and all its associated data will be automatically placed
+      under historical names.
+    </p>
+  </div>
+  <h2 class="mt-4">Required data</h2>
 </section>
 
 <section>

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.ts
@@ -9,6 +9,7 @@ import { ViewChild } from '@angular/core';
 import { Constants } from 'src/app/utils/constants';
 import { DateTime } from 'luxon';
 import { ReloadConfirmationDialogueService } from 'src/app/services/reload-confirmation-dialogue.service';
+import { ToastService } from 'src/app/services/toast.service';
 
 @Component({
   selector: 'app-protected-area-edit-form',
@@ -58,7 +59,8 @@ export class ProtectedAreaEditFormComponent {
     private protectedAreaService: ProtectedAreaService,
     private loadingService: LoadingService,
     private ref: ChangeDetectorRef,
-    private reloadConfirmationDialogueService: ReloadConfirmationDialogueService
+    private reloadConfirmationDialogueService: ReloadConfirmationDialogueService,
+    private toastService: ToastService,
   ) { }
 
   ngOnInit(): void {
@@ -66,9 +68,19 @@ export class ProtectedAreaEditFormComponent {
       this.protectedAreaService.watchCurrentProtectedArea().subscribe((res) => {
         this.currentData = res ? res : {};
         // Populate form with data
-        if (this.currentData && this.updateType === 'minor') {
-          // TODO: Prompt user is another change has been detected after init.
-          this.initForm(this.form, this.currentData);
+        if (this.currentData) {
+          if (this.updateType === 'minor') {
+            // TODO: Prompt user is another change has been detected after init.
+            this.initForm(this.form, this.currentData);
+          } else if (this.currentData.status === 'repealed') {
+            // no major edits on a repealed protected area
+            this.toastService.addMessage(
+              'No major edits permitted on a repealed protected area.',
+              'Invalid action',
+              3
+            );
+            this.router.navigate(['/protected-areas']);
+          }
         }
         this.ref.detectChanges();
       })

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-repeal/protected-area-edit-repeal.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-repeal/protected-area-edit-repeal.component.ts
@@ -8,6 +8,7 @@ import { Constants } from 'src/app/utils/constants';
 import { Utils } from 'src/app/utils/utils';
 import { DateTime } from 'luxon';
 import { ReloadConfirmationDialogueService } from 'src/app/services/reload-confirmation-dialogue.service';
+import { ToastService } from 'src/app/services/toast.service';
 
 @Component({
   selector: 'app-protected-area-edit-repeal',
@@ -48,13 +49,23 @@ export class ProtectedAreaEditRepealComponent {
     private protectedAreaService: ProtectedAreaService,
     private loadingService: LoadingService,
     private ref: ChangeDetectorRef,
-    private reloadConfirmationDialogueService: ReloadConfirmationDialogueService
+    private reloadConfirmationDialogueService: ReloadConfirmationDialogueService,
+    private toastService: ToastService
   ) { }
 
   ngOnInit(): void {
     this.subscriptions.add(
       this.protectedAreaService.watchCurrentProtectedArea().subscribe((res) => {
         this.currentData = res ? res : {};
+        if (this.currentData?.status === 'repealed') {
+          // no repeals on a repealed protected area
+          this.toastService.addMessage(
+            'No repeals permitted on a repealed protected area.',
+            'Invalid action',
+            3
+          );
+          this.router.navigate(['/protected-areas']);
+        }
         this.ref.detectChanges();
       })
     );

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage-routing.module.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage-routing.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes, mapToCanActivate, mapToCanDeactivate } from '@angular/router';
+import { RouterModule, Routes, mapToCanDeactivate } from '@angular/router';
 import { ProtectedAreaEditRepealComponent } from './protected-area-edit-repeal/protected-area-edit-repeal.component';
-import { ProtectedAreaEditComponent } from './protected-area-edit/protected-area-edit.component';
 import { ProtectedAreaManageComponent } from './protected-area-manage.component';
 import { ProtectedAreaEditFormComponent } from './protected-area-edit-form/protected-area-edit-form.component';
 import { UnsavedChangesGuard } from 'src/app/guards/unsaved-changes-guard';
@@ -28,29 +27,31 @@ const routes: Routes = [
         },
       },
       {
-        path: 'edit',
-        component: ProtectedAreaEditComponent,
+        path: 'repeal',
+        component: ProtectedAreaEditRepealComponent,
+        canDeactivate: mapToCanDeactivate([UnsavedChangesGuard]),
         data: {
-          breadcrumb: 'Edit',
+          breadcrumb: 'Repeal',
+          updateType: 'repeal'
         },
-        children: [
-          {
-            path: 'repeal',
-            component: ProtectedAreaEditRepealComponent,
-            canDeactivate: mapToCanDeactivate([UnsavedChangesGuard]),
-            data: {
-              breadcrumb: 'Repeal',
-            },
-          },
-          {
-            path: ':updateType',
-            component: ProtectedAreaEditFormComponent,
-            canDeactivate: mapToCanDeactivate([UnsavedChangesGuard]),
-            data: {
-              breadcrumb: 'PROTECTED_AREA_EDIT',
-            },
-          },
-        ],
+      },
+      {
+        path: 'minor',
+        component: ProtectedAreaEditFormComponent,
+        canDeactivate: mapToCanDeactivate([UnsavedChangesGuard]),
+        data: {
+          breadcrumb: 'Minor Edit',
+          updateType: 'minor'
+        },
+      },
+      {
+        path: 'major',
+        component: ProtectedAreaEditFormComponent,
+        canDeactivate: mapToCanDeactivate([UnsavedChangesGuard]),
+        data: {
+          breadcrumb: 'Legal Name Change',
+          updateType: 'major'
+        },
       },
     ],
   },

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.html
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.html
@@ -14,20 +14,57 @@
 </section>
 
 <ng-template #interactionTemplate>
-  <button
-    *ngIf="state === 'details'"
-    type="button"
-    class="btn btn-outline-primary my-3 my-sm-0"
-    (click)="navigate('edit')"
-  >
-    <i class="bi bi-pen me-2"></i>Edit
-  </button>
-  <button
-    *ngIf="state === 'edit'"
-    type="button"
-    class="btn btn-outline-primary my-3 my-sm-0"
-    (click)="navigate('')"
-  >
-    <i class="bi bi-card-heading me-2"></i>Details
-  </button>
+  <div *ngIf="state === 'details'">
+    <div class="dropdown">
+      <button
+        type="button"
+        class="btn btn-primary d-flex"
+        data-bs-toggle="dropdown"
+        [disabled]="isLoading()"
+      >
+        Edit<div class="bt bi-caret-down-fill ms-3"></div>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <button
+            class="btn btn-link dropdown-item d-flex"
+            (click)="navigate('minor')"
+          >
+            <div class="bi bi-pen-fill me-2"></div>
+            Minor edit
+          </button>
+        </li>
+        <li>
+          <button
+            class="btn btn-link dropdown-item d-flex"
+            (click)="navigate('major')"
+            [disabled]="isRepealed()"
+          >
+            <div class="bi bi-arrow-clockwise me-2"></div>
+            Legal name
+          </button>
+        </li>
+        <li>
+          <button
+            class="btn btn-link dropdown-item d-flex"
+            (click)="navigate('repeal')"
+            [disabled]="isRepealed()"
+          >
+            <div class="bi bi-toggles me-2"></div>
+            Repeal
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div *ngIf="state=== 'edit'">
+    <button
+      type="button"
+      class="btn btn-outline-primary my-3 my-sm-0"
+      (click)="navigate('')"
+      [disabled]="isLoading()"
+    >
+      Details<i class="bi bi-eye-fill ms-2"></i>
+    </button>
+  </div>
 </ng-template>

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.scss
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.scss
@@ -1,3 +1,3 @@
-.test {
-  background-color: #003366;
+.btn-link {
+  text-decoration: none;
 }

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, 
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { BreadcrumbService } from 'src/app/services/breadcrumb.service';
+import { LoadingService } from 'src/app/services/loading.service';
 import { ProtectedAreaService } from 'src/app/services/protected-area.service';
 import { SiteService } from 'src/app/services/site.service';
 import { UrlService } from 'src/app/services/url.service';
@@ -32,6 +33,7 @@ export class ProtectedAreaManageComponent implements OnInit, OnDestroy, AfterVie
     private ref: ChangeDetectorRef,
     private siteService: SiteService,
     private urlService: UrlService,
+    protected loadingService: LoadingService
   ) { }
 
   ngOnInit(): void {
@@ -85,6 +87,14 @@ export class ProtectedAreaManageComponent implements OnInit, OnDestroy, AfterVie
     // this will need to be more robust in the future
     const tags = this.urlService.getRoutePathTags();
     return tags.indexOf('sites') === -1;
+  }
+
+  isRepealed(): boolean {
+    return this.headerData?.status ? this.headerData.status === 'repealed' : false;
+  }
+
+  isLoading(): boolean {
+    return this.loadingService.isLoading();
   }
 
   navigate(path) {

--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.html
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.html
@@ -44,28 +44,21 @@
 </div>
 <div class="container-fluid p-4">
   <h3>Search results</h3>
-  <table class="table table-striped mb-0" aria-label="Name search results">
+  <table class="table table-striped table-hover mb-0" aria-label="Name search results">
     <thead>
       <tr>
         <th scope="col" colspan="1">ID</th>
         <th scope="col">LEGAL NAME</th>
         <th scope="col">PROTECTED AREA STATUS</th>
-        <th scope="col" colspan="1">ACTIONS</th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let item of data">
+      <tr *ngFor="let item of data" class="pointer" (click)="viewItem(item)">
         <th class="py-3" scope="row" colspan="1">{{ item.displayId }}</th>
         <td class="py-3">
           <strong>{{ item.legalName }}</strong>
         </td>
         <td class="py-3">{{ this.utils.upperCaseFirstChar(item.status) }}</td>
-        <td class="action-column" colspan="1">
-          <div class="d-flex">
-            <i class="bi bi-eye me-4" (click)="viewItem(item)" data-bs-toggle="tooltip" data-bs-placement="top" title="View record" ></i>
-            <i class="bi bi-pen-fill" (click)="editItem(item)" data-bs-toggle="tooltip" data-bs-placement="top" title="Edit record" ></i>
-          </div>
-        </td>
       </tr>
     </tbody>
   </table>

--- a/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.scss
+++ b/pdr-admin/src/app/protected-area/protected-area-search/protected-area-search.component.scss
@@ -18,17 +18,6 @@ $table-stripe-dark: #f2f2f2;
   }
 }
 
-.action-column {
-  padding-top: 0.7rem;
-  i {
-    color: #326eaa;
-    font-size: 1.25rem;
-  }
-  i:hover {
-    cursor: pointer;
-  }
-}
-
 .pointer {
-  cursor: default !important;
+  cursor: pointer;
 }

--- a/pdr-admin/src/app/services/loading.service.ts
+++ b/pdr-admin/src/app/services/loading.service.ts
@@ -9,7 +9,7 @@ export class LoadingService {
   public fetchList = new BehaviorSubject({});
   public loading = new BehaviorSubject(false);
 
-  constructor(private logger: LoggerService) {}
+  constructor(private logger: LoggerService) { }
 
   addToFetchList(id, attributes = { loading: true }) {
     this.logger.debug(`addToFetchList: ${id} ${JSON.stringify(attributes)}`);
@@ -35,6 +35,10 @@ export class LoadingService {
     } else if (Object.keys(this.fetchList.value).length <= 0 && this.loading.value) {
       this.loading.next(false);
     }
+  }
+
+  isLoading(): boolean {
+    return this.loading?.value || false;
   }
 
   getFetchList() {

--- a/pdr-admin/src/app/shared/name-header/name-header.component.html
+++ b/pdr-admin/src/app/shared/name-header/name-header.component.html
@@ -1,11 +1,15 @@
 <div class="container-fluid ps-0">
   <section class="pb-4 mb-4 border-bottom">
-    <div class="d-flex justify-content-between flex-wrap mb-1">
-      <h1 class="mb-0">
-        {{ headerData?.displayId || "-" }} <span class="fw-normal">{{ headerData?.legalName || "-" }}</span>
-      </h1>
-      <ng-container [ngTemplateOutlet]="headerData?.interactionTemplate">
-      </ng-container>
+    <div class="d-flex justify-content-between row mb-1">
+      <div class="col-sm-12 col-lg-auto">
+        <h1 class="mb-0">
+          {{ headerData?.displayId || "-" }} <span class="fw-normal">{{ headerData?.legalName || "-" }}</span>
+        </h1>
+      </div>
+      <div class="col-sm-12 col-lg-auto">
+        <ng-container [ngTemplateOutlet]="headerData?.interactionTemplate">
+        </ng-container>
+      </div>
     </div>
     <div class="d-flex justify-content-start text-muted">
       <div class="me-4 fs-5"><strong>Type</strong> Protected Area</div>


### PR DESCRIPTION
Relates to #412 

Removing intermediate `edit` forking page from protected areas routing, replaced with dropdown on root page now.

Removing view/edit icons from search results table.

Routing updates - navigating to `/repeal` or `/major` edit types when the protected area is repealed will now redirect you back to the search page with an error toast.