### PR TITLE
PDR-407 Sites PUT

### DIFF
--- a/pdr-api/__tests__/mock_data.js
+++ b/pdr-api/__tests__/mock_data.js
@@ -35,6 +35,17 @@ exports.MockData = class {
     status: 'established',
     notes: 'some notes'
   };
+  mockRepealParkName3 = {
+    pk: '3',
+    sk: 'Details',
+    createDate: '2023-08-10T16:11:54.513Z',
+    updateDate: '2023-08-10T16:11:54.513Z',
+    legalName: 'Test Park 3',
+    displayName: 'Test Park 3',
+    phoneticName: 'tɛst pɑːk thriː',
+    status: 'repealed',
+    notes: 'some notes'
+  };
   mockPendingParkName1 = {
     pk: '3',
     sk: 'Details',
@@ -66,6 +77,7 @@ exports.MockData = class {
     phoneticName: 'tɛst site wʌn',
     status: 'established',
     lastModifiedBy: 'TESTADMIN',
+    lastVersionDate: '2023-08-10T16:11:54.513Z',
     type: 'site'
   };
   mockOldSite1 = {
@@ -91,6 +103,18 @@ exports.MockData = class {
     displayName: 'Test Site 3-1',
     phoneticName: 'tɛst site wʌn',
     status: 'established',
+    lastModifiedBy: 'TESTADMIN',
+    type: 'site'
+  };
+  mockRepealSite3 = {
+    pk: '1::Site::3',
+    sk: 'Details',
+    createDate: '2023-08-10T16:11:54.513Z',
+    updateDate: '2023-08-10T16:11:54.513Z',
+    legalName: 'Test Site 1-3',
+    displayName: 'Test Site 1-3',
+    phoneticName: 'tɛst site thri',
+    status: 'repealed',
     lastModifiedBy: 'TESTADMIN',
     type: 'site'
   };

--- a/pdr-api/__tests__/mock_data.js
+++ b/pdr-api/__tests__/mock_data.js
@@ -1,3 +1,9 @@
+const {
+  ESTABLISHED_STATE,
+  HISTORICAL_STATE,
+  REPEALED_STATE,
+} = require('/opt/data-constants');
+
 exports.MockData = class {
   // For tests.
   mockConfig = {
@@ -12,7 +18,7 @@ exports.MockData = class {
     legalName: 'Test Park 1',
     displayName: 'Test Park 1',
     phoneticName: 'tɛst pɑːk wʌn',
-    status: 'established',
+    status: ESTABLISHED_STATE,
     notes: 'some notes'
   };
   mockOldParkName1 = {
@@ -21,7 +27,7 @@ exports.MockData = class {
     legalName: 'Old Park 1',
     displayName: 'Old Park 1',
     phoneticName: 'əʊld pɑːk wʌn',
-    status: 'historical',
+    status: HISTORICAL_STATE,
     notes: 'some notes'
   };
   mockCurrentParkName2 = {
@@ -32,7 +38,7 @@ exports.MockData = class {
     legalName: 'Test Park 2',
     displayName: 'Test Park 2',
     phoneticName: 'tɛst pɑːk tuː',
-    status: 'established',
+    status: ESTABLISHED_STATE,
     notes: 'some notes'
   };
   mockRepealParkName3 = {
@@ -43,7 +49,7 @@ exports.MockData = class {
     legalName: 'Test Park 3',
     displayName: 'Test Park 3',
     phoneticName: 'tɛst pɑːk thriː',
-    status: 'repealed',
+    status: REPEALED_STATE,
     notes: 'some notes'
   };
   mockPendingParkName1 = {
@@ -75,7 +81,7 @@ exports.MockData = class {
     legalName: 'Test Site 1-1',
     displayName: 'Test Site 1-1',
     phoneticName: 'tɛst site wʌn',
-    status: 'established',
+    status: ESTABLISHED_STATE,
     lastModifiedBy: 'TESTADMIN',
     lastVersionDate: '2023-08-10T16:11:54.513Z',
     type: 'site'
@@ -86,7 +92,7 @@ exports.MockData = class {
     legalName: 'Old Site 1-1',
     displayName: 'Old Site 1-1',
     phoneticName: 'əʊld site wʌn',
-    status: 'historical',
+    status: HISTORICAL_STATE,
     lastModifiedBy: 'TESTADMIN',
     newLegalName: 'Test Site 1-1',
     newEffectiveDate: '2020-08-10T16:15:50.868Z',
@@ -102,7 +108,7 @@ exports.MockData = class {
     legalName: 'Test Site 3-1',
     displayName: 'Test Site 3-1',
     phoneticName: 'tɛst site wʌn',
-    status: 'established',
+    status: ESTABLISHED_STATE,
     lastModifiedBy: 'TESTADMIN',
     type: 'site'
   };
@@ -114,7 +120,7 @@ exports.MockData = class {
     legalName: 'Test Site 1-3',
     displayName: 'Test Site 1-3',
     phoneticName: 'tɛst site thri',
-    status: 'repealed',
+    status: REPEALED_STATE,
     lastModifiedBy: 'TESTADMIN',
     type: 'site'
   };

--- a/pdr-api/__tests__/settings.js
+++ b/pdr-api/__tests__/settings.js
@@ -69,6 +69,39 @@ async function deleteDB(tableName = TABLE_NAME) {
   }
 }
 
+async function putDB(data, tableName = TABLE_NAME) {
+  const docClient = new DocumentClient({
+    region: AWS_REGION,
+    endpoint: ENDPOINT,
+    convertEmptyValues: true
+  });
+
+  // If data is a single item, make it an array
+  if (!data.length) {
+    data = [data];
+  }
+  for (const item of data) {
+    await docClient.put({
+      TableName: tableName,
+      Item: item
+    }).promise();
+  }
+}
+
+async function getOneDB(pk, sk, tableName = TABLE_NAME) {
+  const dynamodb = new AWS.DynamoDB({
+    region: AWS_REGION,
+    endpoint: DYNAMODB_ENDPOINT_URL
+  });
+  const query = {
+    TableName: tableName,
+    Key: AWS.DynamoDB.Converter.marshall({pk, sk})
+  }
+  let res = await dynamodb.getItem(query).promise();
+  console.log('res:', res);
+  return AWS.DynamoDB.Converter.unmarshall(res.Item);
+}
+
 // Generate hashed text
 function getHashedText(text) {
   return crypto.createHash('md5').update(text).digest('hex');
@@ -83,5 +116,7 @@ module.exports = {
   TIMEZONE,
   createDB,
   deleteDB,
-  getHashedText
+  getOneDB,
+  getHashedText,
+  putDB
 };

--- a/pdr-api/handlers/sites/_identifier/PUT/index.js
+++ b/pdr-api/handlers/sites/_identifier/PUT/index.js
@@ -23,8 +23,7 @@ exports.handler = async (event, context) => {
     const currentTimeISO = getNowISO();
 
     // Perform update.
-    const transactions = await createSitePutTransaction(identifier, body, queryParams?.updateType, user,
-      currentTimeISO);
+    const transactions = await createSitePutTransaction(identifier, body, queryParams?.updateType, user, currentTimeISO);
 
     await batchTransactData(transactions);
 

--- a/pdr-api/handlers/sites/_identifier/PUT/index.js
+++ b/pdr-api/handlers/sites/_identifier/PUT/index.js
@@ -1,0 +1,35 @@
+const { getNowISO, logger, sendResponse } = require('/opt/base');
+const { requireAdmin } = require('/opt/permissions');
+const { createSitePutTransaction } = require('/opt/siteUtils');
+const { batchTransactData } = require('/opt/dynamodb');
+
+exports.handler = async (event, context) => {
+  logger.debug('Site PUT', event);
+
+  // Allow CORS
+  if (event.httpMethod === 'OPTIONS') {
+    return sendResponse(200, {}, 'Success', null, context);
+  }
+
+  try {
+    // Check permissions.
+    requireAdmin(event);
+
+    // Get event variables.
+    const identifier = event.pathParameters.identifier;
+    const queryParams = event.queryStringParameters;
+    const body = JSON.parse(event.body);
+    const user = event.requestContext?.authorizer?.userID;
+    const currentTimeISO = getNowISO();
+
+    // Perform update.
+    const transactions = await createSitePutTransaction(identifier, body, queryParams?.updateType, user,
+      currentTimeISO);
+
+    await batchTransactData(transactions);
+
+    return sendResponse(200, [], `Site ${identifier} updated.`, null, context);
+  } catch (error) {
+    return sendResponse(error?.code || 400, [], error?.msg || 'Error', error?.error || error, context);
+  }
+};

--- a/pdr-api/layers/__tests__/dynamodb.test.js
+++ b/pdr-api/layers/__tests__/dynamodb.test.js
@@ -1,6 +1,7 @@
 const { createDB, deleteDB, getHashedText } = require('../../__tests__/settings');
 const { MockData } = require('../../__tests__/mock_data');
 const AWS = require('aws-sdk');
+const { batchTransactData } = require('../awsUtils/dynamodb');
 
 const data = new MockData;
 let dbClient;
@@ -40,7 +41,7 @@ describe('DynamoDB Layer Tests', () => {
   test('Put one item', async () => {
     const layer = require('../../.aws-sam/build/AWSUtilsLayer/dynamodb');
 
-    const insertedRecord = { pk: { S: '123put' }, sk: { S: 'Details' }};
+    const insertedRecord = { pk: { S: '123put' }, sk: { S: 'Details' } };
 
     // Put the item into the db
     await layer.putItem(insertedRecord);
@@ -58,7 +59,7 @@ describe('DynamoDB Layer Tests', () => {
       ExpressionAttributeValues: {
         ':pk': { S: '1' }
       }
-    }
+    };
     // Regular query
     const regQuery = await layer.runQuery(query);
     expect(regQuery.items).toEqual(expect.arrayContaining([
@@ -78,7 +79,7 @@ describe('DynamoDB Layer Tests', () => {
     const nextEvaluatedKey = {
       pk: { S: lekRes.items[0].pk },
       sk: { S: lekRes.items[0].sk }
-    }
+    };
     expect(querySpy).toHaveBeenCalledTimes(1);
     expect(querySpy).toHaveBeenCalledWith(layerLEKQuery);
     expect(limitQuery.lastEvaluatedKey).not.toEqual(nextEvaluatedKey);
@@ -87,7 +88,7 @@ describe('DynamoDB Layer Tests', () => {
     querySpy.mockClear();
     await layer.runQuery(query, 1, null, false);
     expect(querySpy.mock.calls.length).toBeGreaterThan(1);
-  })
+  });
 
   test('Run Scan', async () => {
     const layer = require('../../.aws-sam/build/AWSUtilsLayer/dynamodb');
@@ -97,7 +98,7 @@ describe('DynamoDB Layer Tests', () => {
       ExpressionAttributeValues: {
         ':pk': { S: '1' }
       }
-    }
+    };
     // Regular scan
     const regScan = await layer.runScan(scan);
     expect(regScan.items).toEqual(expect.arrayContaining([
@@ -117,7 +118,7 @@ describe('DynamoDB Layer Tests', () => {
     const nextEvaluatedKey = {
       pk: { S: lekRes.items[0].pk },
       sk: { S: lekRes.items[0].sk }
-    }
+    };
     expect(scanSpy).toHaveBeenCalledTimes(1);
     expect(scanSpy).toHaveBeenCalledWith(layerLEKScan);
     expect(limitScan.lastEvaluatedKey).not.toEqual(nextEvaluatedKey);
@@ -149,5 +150,88 @@ describe('DynamoDB Layer Tests', () => {
     const remainder = recordSize % chunkSize;
 
     expect(querySpy).toHaveBeenCalledTimes(Math.floor(fullBatchesCount) + remainder);
+  });
+
+  test('Transact Write Item', async () => {
+    const layer = require('../../.aws-sam/build/AWSUtilsLayer/dynamodb');
+    // 1. Delete
+    const db = await layer.dynamodb.scan({ TableName: process.env.TABLE_NAME }).promise();
+    let deleteTransactions = [];
+    for (const item of db.Items) {
+      deleteTransactions.push({
+        TableName: process.env.TABLE_NAME,
+        Key: {
+          pk: item.pk,
+          sk: item.sk
+        }
+      });
+    }
+    await layer.batchTransactData(deleteTransactions, 'Delete');
+    const scanDel = await layer.dynamodb.scan({ TableName: process.env.TABLE_NAME }).promise();
+    expect(scanDel.Items.length).toBe(0);
+    // 2. Put
+    const putItems = [
+      data.mockCurrentParkName1,
+      data.mockCurrentParkName2,
+      data.mockOldParkName1,
+      data.mockParkSite1
+    ];
+    let putTransactions = [];
+    for (const item of putItems) {
+      putTransactions.push({
+        TableName: process.env.TABLE_NAME,
+        Item: AWS.DynamoDB.Converter.marshall(item)
+      })
+    }
+    await layer.batchTransactData(putTransactions);
+    const scanPut = await layer.dynamodb.scan({ TableName: process.env.TABLE_NAME }).promise();
+    expect(scanPut.Items.length).toBe(4);
+    // 3. Update with put
+    // Should perform updates as specified but do a put by default when no action specified
+    const newLegalName1 = 'newLegalName1';
+    const newLegalName2 = 'newLegalName2';
+    const update1 = {
+      TableName: process.env.TABLE_NAME,
+      Key: {
+        pk: { S: data.mockCurrentParkName1.pk },
+        sk: { S: data.mockCurrentParkName1.sk },
+      },
+      UpdateExpression: 'set legalName = :legalName',
+      ExpressionAttributeValues: {
+        ':legalName': { S: newLegalName1 }
+      }
+    }
+    const update2 = {
+      TableName: process.env.TABLE_NAME,
+      Key: {
+        pk: { S: data.mockCurrentParkName2.pk },
+        sk: { S: data.mockCurrentParkName2.sk },
+      },
+      UpdateExpression: 'set legalName = :legalName',
+      ExpressionAttributeValues: {
+        ':legalName': { S: newLegalName2 }
+      }
+    }
+    const updateTransactions = [
+      {
+        action: 'Update',
+        data: update1
+      },
+      {
+        action: 'Update',
+        data: update2
+      },
+      {
+        TableName: process.env.TABLE_NAME,
+        Item: AWS.DynamoDB.Converter.marshall(data.mockCurrentSite1)
+      }
+    ]
+    await batchTransactData(updateTransactions);
+    const scanUpdate = await layer.dynamodb.scan({ TableName: process.env.TABLE_NAME }).promise();
+    expect(scanUpdate.Items.length).toBe(5);
+    const updatedItem1 = scanUpdate.Items.find((e) => e.pk.S === data.mockCurrentParkName1.pk && e.sk.S === data.mockCurrentParkName1.sk);
+    expect(AWS.DynamoDB.Converter.unmarshall(updatedItem1).legalName).toEqual(newLegalName1);
+    const updatedItem2 = scanUpdate.Items.find((e) => e.pk.S === data.mockCurrentParkName2.pk && e.sk.S === data.mockCurrentParkName2.sk);
+    expect(AWS.DynamoDB.Converter.unmarshall(updatedItem2).legalName).toEqual(newLegalName2);
   });
 });

--- a/pdr-api/layers/__tests__/siteUtils.test.js
+++ b/pdr-api/layers/__tests__/siteUtils.test.js
@@ -1,6 +1,7 @@
-const { createDB, deleteDB, getHashedText } = require('../../__tests__/settings');
+const { createDB, deleteDB, getOneDB, getHashedText, putDB } = require('../../__tests__/settings');
 const { MockData } = require('../../__tests__/mock_data');
 const AWS = require('aws-sdk');
+const { batchTransactData } = require('/opt/dynamodb');
 
 const data = new MockData;
 let dbClient;
@@ -30,6 +31,302 @@ describe('Sites Layer Tests', () => {
     expect(records.items.length).toEqual(1);
     expect(records.items[0].sk).toEqual('Site::1');
   });
+})
 
+describe('Validate Sites PUT Request', () => {
+  const OLD_ENV = process.env;
+  let tableName = '';
+  beforeEach(async () => {
+    jest.resetModules();
+    tableName = getHashedText('Validate Sites PUT Request');
+    process.env.TABLE_NAME = tableName;
+    dbClient = await createDB(null, tableName);
+  });
+
+  afterEach(async () => {
+    await deleteDB(process.env.TABLE_NAME);
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Throws error if empty post body', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    try {
+      expect(await layer.validatePutRequest('1', {}, 'minor')).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Empty request body.');
+    }
+  })
+
+  test('Throws error if site does not exist', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    try {
+      expect(await layer.validatePutRequest('X', { arg1: 'arg1' }, 'minor')).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Site not found.');
+    }
+  })
+
+  test('Throws error if trying to repeal park that is already repealed', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockRepealSite3, tableName);
+    try {
+      expect(await layer.validatePutRequest('1::Site::3', { arg1: 'arg1' }, layer.REPEAL_UPDATE_TYPE)).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Forbidden update action.');
+    }
+    try {
+      expect(await layer.validatePutRequest('1::Site::3', { arg1: 'arg1' }, layer.MAJOR_UPDATE_TYPE)).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Forbidden update action.');
+    }
+  })
+
+  test('Throws error if invalid updateType provided', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    const invalidUpdateType = 'invalidUpdateType';
+    try {
+      expect(await layer.validatePutRequest('1::Site::1', { arg1: 'arg1' }, invalidUpdateType)).toThrow();
+    } catch (error) {
+      expect(error.message).toBe(`'${invalidUpdateType}' is not a valid update type.`);
+    }
+  })
+
+  test('Throws error if mandatory fields were not provided', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    // Minor 
+    try {
+      expect(await layer.validatePutRequest('1::Site::1', { lastVersionDate: new Date() }, layer.MINOR_UPDATE_TYPE)).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Missing mandatory fields.');
+    }
+    // Major 
+    try {
+      expect(await layer.validatePutRequest('1::Site::1', { lastVersionDate: new Date(), effectiveDate: new Date() }, layer.MAJOR_UPDATE_TYPE)).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Missing mandatory fields.');
+    }
+  })
+
+  test('Throws if the new legal name in a major update is not different from the old legal name', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    try {
+      expect(await layer.validatePutRequest(
+        '1::Site::1',
+        {
+          lastVersionDate: new Date(),
+          effectiveDate: new Date(),
+          legalName: data.mockCurrentSite1.legalName
+        },
+        layer.MAJOR_UPDATE_TYPE
+      )).toThrow();
+    } catch (error) {
+      expect(error.message).toBe('Invalid mandatory field.');
+    }
+  })
+
+  test('Removes all but notes field from body if repealing', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    let body = {
+      lastVersionDate: 'date1',
+      effectiveDate: 'date2',
+      legalName: 'legalName',
+      displayName: 'displayName',
+      phoneticName: 'phoneticName',
+      notes: 'notes'
+    }
+    expect(await layer.validatePutRequest(
+      '1::Site::1',
+      body,
+      layer.REPEAL_UPDATE_TYPE
+    )).toBeTruthy();
+    expect(body).toEqual({
+      lastVersionDate: 'date1',
+      effectiveDate: 'date2',
+      notes: 'notes'
+    })
+  })
+
+  test('Accepts valid requests', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    const newDisplayName = 'newDisplayName';
+    const newNotes = 'newNotes';
+    const newLegalName = 'legalName';
+    // Minor
+    expect(await layer.validatePutRequest(
+      '1::Site::1',
+      {
+        lastVersionDate: new Date(),
+        effectiveDate: new Date(),
+        displayName: newDisplayName,
+        newNotes: newNotes
+      },
+      layer.MINOR_UPDATE_TYPE
+    )).toBeTruthy();
+    // Major
+    expect(await layer.validatePutRequest(
+      '1::Site::1',
+      {
+        lastVersionDate: new Date(),
+        effectiveDate: new Date(),
+        displayName: newDisplayName,
+        newNotes: newNotes,
+        legalName: newLegalName
+      },
+      layer.MAJOR_UPDATE_TYPE
+    )).toBeTruthy();
+    // Repeal
+    expect(await layer.validatePutRequest(
+      '1::Site::1',
+      {
+        lastVersionDate: new Date(),
+        effectiveDate: new Date(),
+        displayName: newDisplayName,
+        newNotes: newNotes,
+        legalName: newLegalName
+      },
+      layer.REPEAL_UPDATE_TYPE
+    )).toBeTruthy();
+  });
+});
+
+describe('Build Sites PUT Objects', () => {
+  const OLD_ENV = process.env;
+  let tableName = '';
+  beforeEach(async () => {
+    jest.resetModules();
+    tableName = getHashedText('Validate Sites PUT Request');
+    process.env.TABLE_NAME = tableName;
+    dbClient = await createDB(null, tableName);
+  });
+
+  afterEach(async () => {
+    await deleteDB(process.env.TABLE_NAME);
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Builds the object for the protected area site update', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockParkSite1, tableName);
+    const res = await layer.createPASiteUpdate('1::Site::1', 'newSiteName');
+    delete res.TableName;
+    expect(res).toEqual({
+      Key: { pk: { S: '1' }, sk: { S: 'Site::1' } },
+      UpdateExpression: 'SET displayName = :displayName',
+      ExpressionAttributeValues: { ':displayName': { S: 'newSiteName' } },
+      ConditionExpression: 'attribute_exists(pk)'
+    })
+  })
+
+  test('Builds the changelog object for the site update', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    const res = await layer.createChangeLogPut(
+      '1::Site::1',
+      {
+        lastVersionDate: 'lastVersionDate',
+        effectiveDate: 'effectiveDate',
+        legalName: 'newLegalName'
+      },
+      'user1',
+      'updateDate',
+      'established'
+    );
+    const resultData = AWS.DynamoDB.Converter.unmarshall(res.Item);
+    expect(resultData.newLegalName).toEqual('newLegalName');
+    expect(resultData.updateDate).toEqual('updateDate');
+    expect(resultData.lastModifiedBy).toEqual('user1');
+    expect(resultData.status).toEqual('historical');
+    expect(resultData.legalNameChanged).toBeTruthy();
+    expect(resultData.statusChanged).toBeFalsy();
+  })
+
+  test('Builds the transaction for a site name put', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    await putDB(data.mockCurrentSite1, tableName);
+    await putDB(data.mockParkSite1, tableName);
+    const lastVersionDate = data.mockCurrentSite1.lastVersionDate;
+    // Minor
+    const res1 = await layer.createSitePutTransaction(
+      '1::Site::1',
+      {
+        lastVersionDate: lastVersionDate,
+        effectiveDate: 'effectiveDate',
+        legalName: 'newLegalName'
+      },
+      layer.MINOR_UPDATE_TYPE,
+      'user1',
+      'updateDate',
+    );
+    expect(res1.length).toEqual(1);
+    // Major
+    const res2 = await layer.createSitePutTransaction(
+      '1::Site::1',
+      {
+        lastVersionDate: lastVersionDate,
+        effectiveDate: 'effectiveDate',
+        legalName: 'newLegalName2',
+        displayName: 'newDisplayName'
+      },
+      layer.MAJOR_UPDATE_TYPE,
+      'user1',
+      lastVersionDate,
+    );
+    expect(res2.length).toEqual(3);
+    // Repeal
+    const res3 = await layer.createSitePutTransaction(
+      '1::Site::1',
+      {
+        lastVersionDate: lastVersionDate,
+        effectiveDate: 'effectiveDate',
+        legalName: 'newLegalName2',
+      },
+      layer.REPEAL_UPDATE_TYPE,
+      'user1',
+      lastVersionDate,
+    );
+    expect(res3.length).toEqual(2);
+    // Minor edit on a repeal
+    const res4 = await layer.createSitePutTransaction(
+      '1::Site::1',
+      {
+        lastVersionDate: lastVersionDate,
+        effectiveDate: 'effectiveDate',
+        notes: 'newNotes'
+      },
+      layer.MINOR_UPDATE_TYPE,
+      'user2',
+      lastVersionDate,
+    );
+    expect(res4.length).toEqual(1);
+  })
+
+  test('Can minor edit a repealed site name', async () => {
+    const layer = require('../../.aws-sam/build/DataUtilsLayer/siteUtils');
+    const repealedPark = { ...data.mockCurrentSite1, ...{ status: layer.REPEALED_STATE } };
+    await putDB(repealedPark, tableName);
+    await putDB(data.mockParkSite1, tableName);
+    const lastVersionDate = data.mockCurrentSite1.lastVersionDate;
+    const res = await layer.createSitePutTransaction(
+      '1::Site::1',
+      {
+        lastVersionDate: lastVersionDate,
+        effectiveDate: 'effectiveDate',
+        notes: 'newNotes'
+      },
+      layer.MINOR_UPDATE_TYPE,
+      'user2',
+      lastVersionDate,
+    );
+    await batchTransactData(res);
+    let finalObj = await getOneDB('1::Site::1', 'Details', tableName);
+    expect(finalObj.status).toEqual(layer.REPEALED_STATE);
+    expect(finalObj.notes).toEqual('newNotes');
+    expect(finalObj.lastModifiedBy).toEqual('user2');
+  })
 
 })

--- a/pdr-api/layers/awsUtils/dynamodb.js
+++ b/pdr-api/layers/awsUtils/dynamodb.js
@@ -6,9 +6,6 @@ const AWS_REGION = process.env.AWS_REGION || 'ca-central-1';
 const AUDIT_TABLE_NAME = process.env.TABLE_NAME || "Audit";
 const STATUS_INDEX_NAME = process.env.STATUS_INDEX_NAME || "ByStatusOfOrcs";
 const LEGALNAME_INDEX_NAME = process.env.STATUS_INDEX_NAME || "ByLegalName";
-const ESTABLISHED_STATE = 'established';
-const HISTORICAL_STATE = 'historical';
-const REPEALED_STATE = 'repealed';
 
 const TRANSACTION_MAX_SIZE = 100;
 
@@ -248,10 +245,7 @@ async function setSiteStatus(sites, status) {
 module.exports = {
   AUDIT_TABLE_NAME,
   AWS_REGION,
-  ESTABLISHED_STATE,
-  HISTORICAL_STATE,
   LEGALNAME_INDEX_NAME,
-  REPEALED_STATE,
   STATUS_INDEX_NAME,
   TABLE_NAME,
   batchTransactData,

--- a/pdr-api/layers/awsUtils/dynamodb.js
+++ b/pdr-api/layers/awsUtils/dynamodb.js
@@ -10,6 +10,8 @@ const ESTABLISHED_STATE = 'established';
 const HISTORICAL_STATE = 'historical';
 const REPEALED_STATE = 'repealed';
 
+const TRANSACTION_MAX_SIZE = 100;
+
 const options = {
   region: AWS_REGION
 };
@@ -134,23 +136,11 @@ async function putItem(obj, tableName = TABLE_NAME) {
 }
 
 async function batchWriteData(dataToInsert, chunkSize, tableName) {
-  // Assume dataToInsert is already in Dynamo Json format
-
-  // Function to chunk the data into smaller arrays
-  function chunkArray(array, chunkSize) {
-    const result = [];
-    for (let i = 0; i < array.length; i += chunkSize) {
-      result.push(array.slice(i, i + chunkSize));
-    }
-    return result;
-  }
-
   logger.info("dataToInsert");
   logger.debug(JSON.stringify(dataToInsert));
 
   const dataChunks = chunkArray(dataToInsert, chunkSize);
 
-  logger.info("datachunks")
   logger.debug(JSON.stringify(dataChunks));
 
   for (let index = 0; index < dataChunks.length; index++) {
@@ -162,7 +152,7 @@ async function batchWriteData(dataToInsert, chunkSize, tableName) {
       }
     }));
 
-    logger.debug(JSON.stringify(writeRequests))
+    logger.debug(JSON.stringify(writeRequests));
 
     const params = {
       RequestItems: {
@@ -178,6 +168,66 @@ async function batchWriteData(dataToInsert, chunkSize, tableName) {
       logger.error(`Error batch writing items in chunk ${index}:`, err);
     }
   }
+}
+
+// Assume data is already in Dynamo Json format
+// Function to chunk the data into smaller arrays
+function chunkArray(array, chunkSize) {
+  const result = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+    result.push(array.slice(i, i + chunkSize));
+  }
+  return result;
+}
+
+/**
+ * Asynchronously batches and transacts data into DynamoDB.
+ * @async
+ * @param {Array<Object>} data - The array of objects to be transacted into DynamoDB.
+ * If you want the transaction action to differ from the one provided in the `action` argument,
+ * you can provide your data as {action: ('Put', 'Update', 'Delete', 'ConditionExpression'), data: <object> }.
+ * This allows you to perform more than 1 type of action per transaction.
+ * @param {string} [action='Put'] - The default action to perform if not specified for each item ('Put', 'Update', 'Delete', 'ConditionExpression').
+ * @returns {Promise<boolean>} - A Promise that resolves to true if the batch transact operation succeeds.
+ */
+async function batchTransactData(data, action = 'Put') {
+
+  const dataChunks = chunkArray(data, TRANSACTION_MAX_SIZE);
+
+  logger.debug(JSON.stringify(data));
+  logger.debug(JSON.stringify(dataChunks));
+  logger.info('Data items:', data.length);
+  logger.info('Transactions:', dataChunks.length);
+
+  try {
+    for (let index = 0; index < dataChunks.length; index++) {
+      const chunk = dataChunks[index];
+
+      const TransactItems = chunk.map(item => {
+        let op = item?.action || action;
+        switch (op) {
+          case 'ConditionExpression':
+            return { ConditionExpression: item?.data || item };
+          case 'Update':
+            return { Update: item?.data || item };
+          case 'Delete':
+            return { Delete: item?.data || item };
+          case 'Put':
+          default:
+            return { Put: item?.data || item };
+        }
+      });
+
+      logger.debug(JSON.stringify(TransactItems));
+
+      const data = await dynamodb.transactWriteItems({ TransactItems: TransactItems }).promise();
+      logger.debug(`BatchWriteItem response for chunk ${index}:`, data);
+    }
+  } catch (error) {
+    logger.error(`Error batch writing items:`, error);
+    throw error;
+  }
+  return true;
 }
 
 /**
@@ -204,6 +254,7 @@ module.exports = {
   REPEALED_STATE,
   STATUS_INDEX_NAME,
   TABLE_NAME,
+  batchTransactData,
   batchWriteData,
   dynamodb,
   getOne,

--- a/pdr-api/layers/awsUtils/nodejs/package.json
+++ b/pdr-api/layers/awsUtils/nodejs/package.json
@@ -4,7 +4,7 @@
   "author": "Team Osprey",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.1441.0",
-    "@opensearch-project/opensearch": "^2.4.0"
+    "@opensearch-project/opensearch": "^2.4.0",
+    "aws-sdk": "^2.1585.0"
   }
 }

--- a/pdr-api/layers/base/nodejs/package.json
+++ b/pdr-api/layers/base/nodejs/package.json
@@ -4,9 +4,10 @@
   "author": "Team Osprey",
   "license": "MIT",
   "dependencies": {
-    "winston": "^3.10.0",
     "jsonwebtoken": "^9.0.0",
-    "jwks-rsa": "^3.0.0"
+    "jwks-rsa": "^3.0.0",
+    "luxon": "^3.4.4",
+    "winston": "^3.10.0"
   },
   "scripts": {
     "test": "mocha tests/unit/"

--- a/pdr-api/layers/base/permissions.js
+++ b/pdr-api/layers/base/permissions.js
@@ -4,7 +4,7 @@ const INVALID_TOKEN = {
   decoded: false,
   data: null
 };
-const { logger } = require('./base');
+const { Exception, logger } = require('./base');
 
 async function decodeJWT(event, issuer, jwksUri) {
   const token = event.headers.Authorization;
@@ -158,7 +158,26 @@ function resolvePermissions(token) {
   };
 };
 
+/**
+ * Checks if the user invoking the function is an admin.
+ * @param {Object} lambdaEvent - The Lambda event object.
+ * @returns {boolean} Returns true if the user is an admin, otherwise throws an error.
+ * @throws {Error} Throws an error with details if the user is not an admin.
+ */
+function requireAdmin(lambdaEvent) {
+  const isAdmin = JSON.parse(lambdaEvent?.requestContext?.authorizer?.isAdmin);
+  if (!isAdmin) {
+    throw new Exception('User does not have the permissions to perform this action.', {
+      code: 403,
+      error: 'Unauthorized to perform this function.'
+    });
+  }
+  return true;
+}
+
+
 module.exports = {
   decodeJWT,
+  requireAdmin,
   resolvePermissions
 };

--- a/pdr-api/layers/dataUtils/data-constants.js
+++ b/pdr-api/layers/dataUtils/data-constants.js
@@ -1,0 +1,41 @@
+const SITE_MAIN_SK = 'Details';
+
+const MINOR_UPDATE_TYPE = 'minor';
+const MAJOR_UPDATE_TYPE = 'major';
+const REPEAL_UPDATE_TYPE = 'repeal';
+const UPDATE_TYPES = [
+  MAJOR_UPDATE_TYPE,
+  MINOR_UPDATE_TYPE,
+  REPEAL_UPDATE_TYPE
+];
+
+const ESTABLISHED_STATE = 'established';
+const HISTORICAL_STATE = 'historical';
+const REPEALED_STATE = 'repealed';
+
+const MANDATORY_PUT_FIELDS = [
+  'effectiveDate',
+  'lastVersionDate'
+];
+
+const OPTIONAL_PUT_FIELDS = [
+  'audioClip',
+  'displayName',
+  'legalName',
+  'notes',
+  'phoneticName',
+  'searchTerms'
+];
+
+module.exports = {
+  ESTABLISHED_STATE,
+  HISTORICAL_STATE,
+  MAJOR_UPDATE_TYPE,
+  MANDATORY_PUT_FIELDS,
+  MINOR_UPDATE_TYPE,
+  OPTIONAL_PUT_FIELDS,
+  REPEAL_UPDATE_TYPE,
+  REPEALED_STATE,
+  SITE_MAIN_SK,
+  UPDATE_TYPES
+}

--- a/pdr-api/layers/dataUtils/nodejs/package.json
+++ b/pdr-api/layers/dataUtils/nodejs/package.json
@@ -4,6 +4,7 @@
   "author": "Team Osprey",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/util-dynamodb": "^3.538.0",
     "aws-sdk": "^2.1441.0"
   }
 }

--- a/pdr-api/layers/dataUtils/siteUtils.js
+++ b/pdr-api/layers/dataUtils/siteUtils.js
@@ -1,5 +1,34 @@
+const { Exception } = require('/opt/base');
 const { logger } = require('/opt/base');
-const { TABLE_NAME, runQuery } = require('/opt/dynamodb');
+const { TABLE_NAME, runQuery, getOne } = require('/opt/dynamodb');
+const { marshall } = require('@aws-sdk/util-dynamodb');
+
+const MINOR_UPDATE_TYPE = 'minor';
+const MAJOR_UPDATE_TYPE = 'major';
+const REPEAL_UPDATE_TYPE = 'repeal';
+const UPDATE_TYPES = [
+  MAJOR_UPDATE_TYPE,
+  MINOR_UPDATE_TYPE,
+  REPEAL_UPDATE_TYPE
+];
+
+const ESTABLISHED_STATE = 'established';
+const HISTORICAL_STATE = 'historical';
+const REPEALED_STATE = 'repealed';
+
+const MANDATORY_PUT_FIELDS = [
+  'effectiveDate',
+  'lastVersionDate'
+];
+
+const OPTIONAL_PUT_FIELDS = [
+  'audioClip',
+  'displayName',
+  'legalName',
+  'notes',
+  'phoneticName',
+  'searchTerms'
+];
 
 /**
  * Asynchronously retrieves all sites for a given protected area.
@@ -27,6 +56,280 @@ async function getSitesForProtectedArea(identifier) {
   return res;
 }
 
+/**
+ * Validates a PUT request for updating site details.
+ * @async
+ * @param {string} identifier - The identifier of the site.
+ * @param {Object} body - The body of the PUT request containing the updated site details.
+ * @param {string} updateType - The type of update: 'minor', 'major', or 'repeal'.
+ * @returns {Promise<boolean>} - A promise that resolves to true if the validation passes.
+ * @throws {Exception} Throws an exception if the validation fails.
+ */
+async function validatePutRequest(identifier, body, updateType) {
+  try {
+    if (!body || !Object.keys(body)?.length) {
+      throw new Exception('Empty request body.', {
+        code: 400,
+        error: 'Request body cannot be empty.'
+      });
+    }
+
+    // Check if site exists
+    const site = await getOne(identifier, 'Details');
+    if (!Object.keys(site).length) {
+      // Throw if site not found
+      throw new Exception(`Site not found.`, {
+        code: 400,
+        error: `No site for ${identifier} found.`
+      }
+      );
+    };
+
+    // Check if trying to perform major update on repealed site
+    if (site.status === REPEALED_STATE) {
+      if (updateType === MAJOR_UPDATE_TYPE || updateType === REPEAL_UPDATE_TYPE) {
+        // Cannot perform major update on repealed site
+        throw new Exception('Forbidden update action.', {
+          code: 400,
+          error: 'Cannot perform a major update or repeal on an already-repealed site.'
+        });
+      }
+    }
+
+    // Check updateType
+    let checkFields = [...MANDATORY_PUT_FIELDS];
+    switch (updateType) {
+      case MINOR_UPDATE_TYPE:
+        break;
+      case MAJOR_UPDATE_TYPE:
+        checkFields.push('legalName');
+        break;
+      case REPEAL_UPDATE_TYPE:
+        for (const field of Object.keys(body)) {
+          if (field !== 'notes' && checkFields.indexOf(field) === -1) {
+            delete body[field];
+          }
+        }
+        break;
+      default:
+        throw new Exception(`'${updateType}' is not a valid update type.`, {
+          code: 400,
+          error: `A valid update type (${UPDATE_TYPES.join(', ')}) was not provided.`
+        });
+    }
+
+    // Check if mandatory fields were provided
+    for (const field of checkFields) {
+      if (!body.hasOwnProperty(field) || !body[field]) {
+        throw new Exception('Missing mandatory fields.', {
+          code: 400,
+          error: `For updateType '${updateType}', the following fields must be provided in the request body: ${checkFields.join(', ')}.`
+        });
+      }
+    }
+
+    // If major update, check that the new legalName is different than the current.
+    if (updateType === MAJOR_UPDATE_TYPE && body?.legalName === site.legalName) {
+      // New legalName is not different
+      throw new Exception('Invalid mandatory field.', {
+        code: 400,
+        error: `Legal name changes must have a different legalName than the current established name (current legalName: ${site.legalName})`
+      });
+    }
+
+    // Body & updateType are valid, site exists.
+    return true;
+  } catch (error) {
+    logger.error('Site PUT request failed validation.');
+    throw error;
+  }
+}
+
+/**
+ * Creates a transaction to update site details.
+ * @async
+ * @function createSitePutTransaction
+ * @param {string} identifier - The identifier of the site.
+ * @param {Object} body - The body of the PUT request containing the updated site details.
+ * @param {string} updateType - The type of update: 'minor', 'major', or 'repeal'.
+ * @param {string} user - The user performing the update.
+ * @param {string} [currentTimeISO=null] - The current time in ISO format. Defaults to null.
+ * @returns {Promise<Object[]>} - A promise that resolves to an array of put transactions.
+ * @throws {Exception} Throws an exception if the transaction creation fails.
+ */
+const createSitePutTransaction = async function (identifier, body, updateType, user, currentTimeISO = null) {
+  try {
+    // Validate request
+    await validatePutRequest(identifier, body, updateType);
+
+    // 1. Update the existing main site object
+    // Get existing site object (pk: <pAreaId>::Site::<siteId>, sk: Details)
+    const site = await getOne(identifier, 'Details');
+
+    // Determine next status
+    let newStatus = site.status;
+    if (updateType === REPEAL_UPDATE_TYPE) {
+      newStatus = REPEALED_STATE;
+    }
+
+    // Build update transaction for main site object
+    let updatedAttributeValues = {
+      ':updateDate': { S: currentTimeISO },
+      ':lastModifiedBy': { S: user },
+      ':status': { S: newStatus },
+      ':lastVersionDate': { S: body.lastVersionDate },
+      ':effectiveDate': { S: body.effectiveDate }
+    };
+    let updateExpression = ['SET updateDate = :updateDate, #status = :status, lastModifiedBy = :lastModifiedBy, effectiveDate = :effectiveDate'];
+
+    // Add optional fields to update
+    if (updateType !== REPEAL_UPDATE_TYPE) {
+      for (const field of OPTIONAL_PUT_FIELDS) {
+        if (body.hasOwnProperty(field)) {
+          updatedAttributeValues[`:${field}`] = { S: body[field] || '' };
+          updateExpression.push(`${field} = :${field}`);
+        }
+      }
+    }
+
+    // Build update transaction for site object
+    let siteUpdate = {
+      TableName: TABLE_NAME,
+      Key: {
+        pk: { S: identifier },
+        sk: { S: 'Details' }
+      },
+      ExpressionAttributeValues: updatedAttributeValues,
+      ExpressionAttributeNames: { '#status': 'status' },
+      UpdateExpression: updateExpression.join(', '),
+      ConditionExpression: 'updateDate = :lastVersionDate',
+    };
+
+    // If major change (not repealed), deny if legalName is the same
+    if (updateType === MAJOR_UPDATE_TYPE) {
+      siteUpdate.ExpressionAttributeValues[':oldLegalName'] = { S: body.legalName };
+      siteUpdate.ConditionExpression += ' AND legalName <> :oldLegalName';
+    }
+
+    // Add to transaction list
+    let putTransactions = [{ action: 'Update', data: siteUpdate }];
+
+    logger.debug('Site record update parameters:', siteUpdate);
+
+    // 2. Update the protected area site object (pk: <pAreaId>, sk: Site::<siteId>)
+    // Only update if the displayName property is changing
+    if (body?.displayName) {
+      const paSitePut = createPASiteUpdate(identifier, body.displayName);
+      putTransactions.push({ action: 'Update', data: paSitePut });
+    }
+
+    // 3. Create changelog item
+    // Only create a changelog item if doing a major change or repeal
+    if (updateType === MAJOR_UPDATE_TYPE || updateType === REPEAL_UPDATE_TYPE) {
+      putTransactions.push(await createChangeLogPut(identifier, body, user, currentTimeISO, newStatus));
+    }
+
+    // Return an array of put actions
+    return putTransactions;
+
+  } catch (error) {
+    logger.error('Failed to create site update transaction');
+    throw error;
+  }
+};
+
+/**
+ * Creates a transaction to update the display name of a protected area site.
+ * @function createPASiteUpdate
+ * @param {string} identifier - The identifier of the site.
+ * @param {string} displayName - The new display name for the site.
+ * @returns {Object} - The update transaction for the protected area site object.
+ * @throws {Exception} Throws an exception if the transaction creation fails.
+ */
+const createPASiteUpdate = function (identifier, displayName) {
+  try {
+
+    // Build update transaction for protected area site object
+    const paSiteUpdate = {
+      TableName: TABLE_NAME,
+      Key: {
+        pk: { S: identifier.split('::')[0] },
+        sk: { S: `Site::${identifier.split('::')[2]}` }
+      },
+      UpdateExpression: 'SET displayName = :displayName',
+      ExpressionAttributeValues: {
+        ':displayName': { S: displayName }
+      },
+      ConditionExpression: 'attribute_exists(pk)'
+    };
+
+    logger.debug('Protected area site record update parameters:', JSON.stringify(paSiteUpdate));
+
+    return paSiteUpdate;
+  } catch (error) {
+    logger.error('Error creating protected area site PUT');
+    throw error;
+  }
+};
+
+/**
+ * Creates a transaction to put a changelog item for site updates.
+ * @async
+ * @function createChangeLogPut
+ * @param {string} identifier - The identifier of the site.
+ * @param {Object} body - The body of the PUT request containing the updated site details.
+ * @param {string} user - The user performing the update.
+ * @param {string} currentTimeISO - The current time in ISO format.
+ * @param {string} newStatus - The new status of the site.
+ * @returns {Promise<Object>} - A promise that resolves to the changelog put object.
+ * @throws {Exception} Throws an exception if the transaction creation fails.
+ */
+const createChangeLogPut = async function (identifier, body, user, currentTimeISO, newStatus) {
+  // Get the existing record
+  try {
+    const oldSite = await getOne(identifier, 'Details');
+
+    // Fields that will overwrite
+    const fields = {
+      sk: currentTimeISO,
+      updateDate: currentTimeISO,
+      lastModifiedBy: user,
+      newLegalName: body?.legalName || oldSite.legalName,
+      newEffectiveDate: body?.effectiveDate,
+      newStatus: newStatus,
+      status: HISTORICAL_STATE,
+      legalNameChanged: body?.legalName && body?.legalName !== oldSite.legalName,
+      statusChanged: newStatus !== oldSite.status
+    };
+
+    // Create changelog put object
+    let changelogItem = { ...oldSite, ...fields };
+    const changelogPut = {
+      TableName: TABLE_NAME,
+      Item: marshall(changelogItem, {
+        removeUndefinedValues: true
+      })
+    };
+
+    logger.debug('Site changelog record update parameters:', changelogPut);
+
+    return changelogPut;
+  } catch (error) {
+    logger.error('Error creating site changelog item PUT');
+    throw error;
+  }
+};
+
 module.exports = {
-  getSitesForProtectedArea
+  ESTABLISHED_STATE,
+  HISTORICAL_STATE,
+  MINOR_UPDATE_TYPE,
+  MAJOR_UPDATE_TYPE,
+  REPEALED_STATE,
+  REPEAL_UPDATE_TYPE,
+  createChangeLogPut,
+  createPASiteUpdate,
+  createSitePutTransaction,
+  getSitesForProtectedArea,
+  validatePutRequest,
 };

--- a/pdr-api/package.json
+++ b/pdr-api/package.json
@@ -24,7 +24,8 @@
       "^/opt/dynamodb": "<rootDir>/.aws-sam/build/AWSUtilsLayer/dynamodb",
       "^/opt/base": "<rootDir>/.aws-sam/build/BaseLayer/base",
       "^/opt/opensearch": "<rootDir>/.aws-sam/build/AWSUtilsLayer/opensearch",
-      "^/opt/siteUtils": "<rootDir>/.aws-sam/build/DataUtilsLayer/siteUtils"
+      "^/opt/siteUtils": "<rootDir>/.aws-sam/build/DataUtilsLayer/siteUtils",
+      "^/opt/data-constants": "<rootDir>/.aws-sam/build/DataUtilsLayer/data-constants"
     }
   },
   "dependencies": {

--- a/pdr-api/postman/Parks Data Register.postman_collection.json
+++ b/pdr-api/postman/Parks Data Register.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "5e8ff27b-5007-49ec-9d94-0646c0155f1b",
+		"_postman_id": "0b78509c-c8e0-4992-8951-43ccd576dd20",
 		"name": "Parks Data Register",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21509305"
+		"_exporter_id": "14509064"
 	},
 	"item": [
 		{
@@ -424,7 +424,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{base_url}}/sites/:identifier",
+									"raw": "{{base_url}}/sites/:identifier?status=repealed",
 									"host": [
 										"{{base_url}}"
 									],
@@ -440,8 +440,142 @@
 										},
 										{
 											"key": "status",
-											"value": "historical",
-											"disabled": true
+											"value": "established"
+										}
+									],
+									"variable": [
+										{
+											"key": "identifier",
+											"value": "300::Site::1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Put Specific Site (Minor)",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"effectiveDate\": \"1911-03-03\",\r\n    \"lastVersionDate\": \"2024-03-25T09:55:24.664-07:00\",\r\n    \"legalName\": \"new legal name\",\r\n    \"displayName\": \"new display name\",\r\n    \"notes\": \"new notes\",\r\n    \"phoneticName\": \"phoneticName\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/sites/:identifier?updateType=minor",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"sites",
+										":identifier"
+									],
+									"query": [
+										{
+											"key": "updateType",
+											"value": "minor"
+										}
+									],
+									"variable": [
+										{
+											"key": "identifier",
+											"value": "300::Site::1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Put Specific Site (Major)",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"lastVersionDate\": \"2024-03-25T09:20:14.141-07:00\",\r\n    \"legalName\": \"New Albas Site 3\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/sites/:identifier?updateType=major",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"sites",
+										":identifier"
+									],
+									"query": [
+										{
+											"key": "updateType",
+											"value": "major"
+										}
+									],
+									"variable": [
+										{
+											"key": "identifier",
+											"value": "300::Site::1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Put Specific Site (Repeal)",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-api-key",
+										"value": "{{x-api-key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"effectiveDate\": \"1911-03-01\",\r\n    \"lastVersionDate\": \"2024-03-25T09:16:52.544-07:00\",\r\n    \"notes\": \"Some Notes 6\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{base_url}}/sites/:identifier?updateType=repeal",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"sites",
+										":identifier"
+									],
+									"query": [
+										{
+											"key": "updateType",
+											"value": "repeal"
 										}
 									],
 									"variable": [

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -703,6 +703,37 @@ Resources:
               Authorizer: NONE
               OverrideApiAuth: true
 
+  SitePut:
+    FunctionName: SitePut
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/sites/_identifier/PUT
+      Handler: index.handler
+      Layers:
+        - !Ref BaseLayer
+        - !Ref AWSUtilsLayer
+        - !Ref DataUtilsLayer
+      Runtime: nodejs18.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Site PUT lambda function
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref TableNameRegister
+          LOG_LEVEL: info
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableNameRegister
+      Events:
+        ParkNamePut:
+          Type: Api
+          Properties:
+            Path: /sites/{identifier}
+            Method: PUT
+            RestApiId: !Ref ApiDeployment
+
 Outputs:
   #   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   #   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
Relates to #407 

Adds site PUT endpoint to API. Behaves analogously to the Protected Area Names PUT endpoint.

Employs new design philosophy of keeping the lambda handlers very lean, and moving logic based code to a layer. 