### PR TITLE
PDR-326 repeal all child sites when repealing protected area

### DIFF
--- a/pdr-api/layers/dataUtils/siteUtils.js
+++ b/pdr-api/layers/dataUtils/siteUtils.js
@@ -42,6 +42,16 @@ async function getSitesForProtectedArea(identifier) {
   return res;
 }
 
+async function getSiteDetailsForProtectedArea(identifier) {
+  const sites = await getSitesForProtectedArea(identifier);
+  let siteDetails = [];
+  for (const site of sites.items) {
+    logger.info('Get all site details for a protected area');
+    siteDetails.push(await getOne(`${site.pk}::${site.sk}`, 'Details'));
+  }
+  return siteDetails;
+}
+
 /**
  * Validates a PUT request for updating site details.
  * @async
@@ -325,5 +335,6 @@ module.exports = {
   createPASiteUpdate,
   createSitePutTransaction,
   getSitesForProtectedArea,
+  getSiteDetailsForProtectedArea,
   validatePutRequest,
 };


### PR DESCRIPTION
Relates to #326

When repealing a protected area, the system now creates a transaction to repeal the child sites at the same time. All transactions are run together (up until the transaction item limit of 100, at which point the transactions are performed in groups of at most 100).