### PR TITLE
PDR-402-2 removing notes field as per designs

### DIFF
--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-edit-form/protected-area-edit-form.component.ts
@@ -76,7 +76,7 @@ export class ProtectedAreaEditFormComponent {
         this.currentData = res ? res : {};
         // Populate form with data
         if (this.currentData) {
-          if (this.updateType === 'minor') {
+          if (this.updateType === 'minor' || this.updateType === 'edit-repeal') {
             // TODO: Prompt user is another change has been detected after init.
             this.initForm();
           } else if (this.currentData.status === 'repealed') {

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage-routing.module.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage-routing.module.ts
@@ -23,7 +23,7 @@ const routes: Routes = [
         component: ProtectedAreaEditFormComponent,
         data: {
           breadcrumb: 'Edit Repealed',
-          updateType: 'minor',
+          updateType: 'edit-repeal',
         },
       },
       {

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.html
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.html
@@ -28,7 +28,7 @@
         <li>
           <button
             class="btn btn-link dropdown-item d-flex"
-            (click)="navigate('minor')"
+            (click)="navigateMinorEdit()"
           >
             <div class="bi bi-pen-fill me-2"></div>
             Minor edit

--- a/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.ts
+++ b/pdr-admin/src/app/protected-area/protected-area-manage/protected-area-manage.component.ts
@@ -97,6 +97,14 @@ export class ProtectedAreaManageComponent implements OnInit, OnDestroy, AfterVie
     return this.loadingService.isLoading();
   }
 
+  navigateMinorEdit() {
+    if (this.isRepealed()) {
+      this.navigate('edit-repealed');
+      return;
+    }
+    this.navigate('minor');
+  }
+
   navigate(path) {
     let route = ['protected-areas', this.id];
     // Business rule: if record is repealed we skip directly to minor edit.

--- a/pdr-admin/src/app/shared/edit-form/edit-form.html
+++ b/pdr-admin/src/app/shared/edit-form/edit-form.html
@@ -140,7 +140,7 @@
   </section>
 </div>
 
-<section *ngIf="updateType !== 'edit-repeal'">
+<section *ngIf="updateType !== 'edit-repeal' && updateType !== 'repeal'">
   <div class="row mt-4">
     <div class="col-12 col-xl-8">
       <ngds-text-input


### PR DESCRIPTION
In both protected-areas and sites, there were some extraneous fields present when repealing or editing a repealed record. This change ensures that only the effective date field is present when repealing or editing a repealed record as per the designs.