### PR TITLE
PDR-452: lazy loading causing issues with site datepicker

### DIFF
--- a/pdr-admin/src/app/protected-area/site/site-manage/site-edit-form/site-edit-form.component.ts
+++ b/pdr-admin/src/app/protected-area/site/site-manage/site-edit-form/site-edit-form.component.ts
@@ -127,6 +127,7 @@ export class SiteEditFormComponent implements OnInit, OnDestroy {
     }
   }
 
+
   getEffectiveDateLabel() {
     switch (this.updateType) {
       case Constants.editTypes.REPEAL_EDIT_TYPE:
@@ -186,6 +187,12 @@ export class SiteEditFormComponent implements OnInit, OnDestroy {
 
   // empty function to allow use of shared template
   onDatePickerInteract() {
+    // TODO: Fix this bug
+    // For some reason, if we do detectChanages outisde of a setTimeout
+    // Month picker and year picker breaks
+    setTimeout(() => {
+      this.cdr.detectChanges();
+    }, 0);
   }
 
   // empty function to allow use of shared template


### PR DESCRIPTION
Fixes #452.

Not a datepicker issue so much as a lazy loading issue. The datepicker rendering changes but the old rendering is not removed. Patched in a similar way to protected areas - `detectChanges` wrapped in a 0s timeout. 