### PR TITLE
PDR-332-1 showing correct datatype in header

### DIFF
--- a/pdr-admin/package.json
+++ b/pdr-admin/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "^16.2.12",
     "@angular/router": "^16.2.12",
     "@digitalspace/bcparks-bootstrap-theme": "^1.3.5",
-    "@digitalspace/ngds-forms": "^0.0.109",
+    "@digitalspace/ngds-forms": "^0.0.110",
     "@popperjs/core": "^2.11.8",
     "@types/bootstrap": "^5.2.10",
     "bootstrap": "^5.3.2",

--- a/pdr-admin/src/app/shared/name-header/name-header.component.html
+++ b/pdr-admin/src/app/shared/name-header/name-header.component.html
@@ -12,7 +12,7 @@
       </div>
     </div>
     <div class="d-flex justify-content-start text-muted">
-      <div class="me-4 fs-5"><strong>Type</strong> Protected Area</div>
+      <div class="me-4 fs-5"><strong>Type </strong>{{ headerData?.type || '-'}}</div>
       <div class="me-4 fs-5">
         <strong>Status</strong> {{ this.utils.upperCaseFirstChar(headerData?.status) || "-" }}
       </div>

--- a/pdr-admin/yarn.lock
+++ b/pdr-admin/yarn.lock
@@ -1267,10 +1267,10 @@
     bootstrap "^5.3.2"
     jquery "^3.6.0"
 
-"@digitalspace/ngds-forms@^0.0.109":
-  version "0.0.109"
-  resolved "https://registry.yarnpkg.com/@digitalspace/ngds-forms/-/ngds-forms-0.0.109.tgz#4cbf4d621bfeaa38d3a374cc8f4b440f83d45937"
-  integrity sha512-9qQC1Kg4631T6PNJDH0G3jBzZdpZYpQl2WwSs8knlPCN5y6elUBa0lg7QuoL25i+8nSiyFB2nEaw1L1Eg4CvsQ==
+"@digitalspace/ngds-forms@^0.0.110":
+  version "0.0.110"
+  resolved "https://registry.yarnpkg.com/@digitalspace/ngds-forms/-/ngds-forms-0.0.110.tgz#e8aea2164e55332a90d00f553dce6a30e84679a8"
+  integrity sha512-lBJA14tYG+ef5F/ad+5rLDKYp9ABetUXgpYYetlYsAWUDu4pnl0KOzrXY0B0WTE35eb3uXnWGnA9y1y30/YyRA==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
Relates to #332.

Record type (Protected Area) was hardcoded in the header. Now record type is dynamic (Site or Protected Area).

Also bumped NGDS-Forms to v0.0.110 to fix a small issue where invalid fields where simply displaying the text 'true' when they were invalid instead of the more informative defaults.