### PR TITLE
PDR-326 fixing allowed updateTypes for PAs

### DIFF
--- a/pdr-admin/src/app/services/protected-area.service.ts
+++ b/pdr-admin/src/app/services/protected-area.service.ts
@@ -32,7 +32,7 @@ export class ProtectedAreaService {
     private loggerService: LoggerService,
     private toastService: ToastService,
     private eventService: EventService
-  ) {}
+  ) { }
   async fetchData(id) {
     this.loadingService.addToFetchList(Constants.dataIds.SEARCH_RESULTS);
     let queryParams = {};
@@ -70,8 +70,7 @@ export class ProtectedAreaService {
 
   async edit(pk, putObj, updateType) {
     this.loadingService.addToFetchList(Constants.dataIds.PROTECTED_AREA_PUT);
-
-    if (updateType !== 'minor' && updateType !== 'major') throw 'UpdateType must be either minor or major.';
+    if (updateType === Constants.editTypes.REPEAL_EDIT_TYPE) throw `UpdateType cannot be ${Constants.editTypes.REPEAL_EDIT_TYPE}`;
 
     delete putObj.pk;
     delete putObj.sk;


### PR DESCRIPTION
Before, the protected area service prevented any `edits` unless the edit type was major or minor. There was a separate function for the repealed type and the edit-repeal was considered a minor edit.

With the changes implemented with the new sites features, the `edit-repeal` update type is now distinct so must also be included in the types of edits allowed in the protected area service.