### PR TITLE
PDR-332 fixing repeal edit for protected areas

### DIFF
--- a/pdr-admin/src/app/services/protected-area.service.ts
+++ b/pdr-admin/src/app/services/protected-area.service.ts
@@ -72,6 +72,10 @@ export class ProtectedAreaService {
     this.loadingService.addToFetchList(Constants.dataIds.PROTECTED_AREA_PUT);
     if (updateType === Constants.editTypes.REPEAL_EDIT_TYPE) throw `UpdateType cannot be ${Constants.editTypes.REPEAL_EDIT_TYPE}`;
 
+    if (updateType === Constants.editTypes.EDIT_REPEAL_EDIT_TYPE) {
+      updateType = Constants.editTypes.MINOR_EDIT_TYPE;
+    }
+
     delete putObj.pk;
     delete putObj.sk;
 


### PR DESCRIPTION
Relates to #332 

Must convert `edit-repeal` updateType to `minor` before passing to API.