### PR TITLE
NOBUG - Adding settings.json formatting file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "editor.wordWrap": "wordWrapColumn",
+  "editor.wordWrapColumn": 120,
+  "editor.tabSize": 2,
+  "editor.indentSize": "tabSize",
+  "editor.renderFinalNewline": "on",
+  "files.encoding": "utf8",
+  "files.trimTrailingWhitespace": true,
+  "[typescript]": {
+    "format.semicolons": "insert",
+    "preferences.quoteStyle": "auto"
+  },
+  "[javascript]": {
+    "format.semicolons": "insert",
+    "preferences.quoteStyle": "auto"
+  },
+  "[html]": {
+    "format.wrapAttributesIndentSize": 2,
+    "format.wrapAttributes": "force-expand-multiline",
+    "html.completion.attributeDefaultValue": "doublequotes",
+    "format.wrapLineLength": 120
+  }
+}


### PR DESCRIPTION
Adding a `settings.json` file to synchronize formatting settings between `vscode` contributors to the project. Theoretically if this is included in your workplaces, the workplace formatting settings should override user settings - https://code.visualstudio.com/docs/getstarted/settings, but we need to confirm that it actually does function in this way & that the folder is saved in the right place.