### PR TITLE
BRS-559: Fee Register send back fixes for DELETE

### DIFF
--- a/pdr-api/__tests__/mock_data.js
+++ b/pdr-api/__tests__/mock_data.js
@@ -135,6 +135,13 @@ exports.MockData = class {
     Night: 77
   };
 
+  mockFees2 = {
+    pk: '66::FEES',
+    sk: 'Fake Feature::Pretend Camping::Party',
+    Night: 77,
+    Day: 66
+  };
+
   allData = () => {
     return [
       this.mockConfig,

--- a/pdr-api/handlers/fees/POST/index.js
+++ b/pdr-api/handlers/fees/POST/index.js
@@ -2,6 +2,7 @@
 const { sendResponse, logger } = require('/opt/base');
 const { TABLE_NAME, putItem } = require('/opt/dynamodb');
 const { marshall } = require('@aws-sdk/util-dynamodb');
+const { FEES_OPTIONAL_PUT_FIELDS } = require('/opt/data-constants');
 
 exports.handler = async function (event, context) {
   logger.debug('Post:', event); 
@@ -21,6 +22,12 @@ exports.handler = async function (event, context) {
         logger.error(`Bad Request - Missing Param: ${param}`);
         return sendResponse(400, {}, 'Bad Request', `Missing Param: ${param}`, context);
       }
+    }
+
+    //Only allow the valid charge by parameters
+    if(!FEES_OPTIONAL_PUT_FIELDS.includes(queryParams.chargeBy)){
+      logger.error(`Bad Request - Invalid Param: ${queryParams.chargeBy}`);
+      return sendResponse(400, {}, 'Bad Request', `Invalid chargeBy Param: ${queryParams.chargeBy}`, context);
     }
 
     // Check if the user is an admin

--- a/pdr-api/handlers/fees/_tests_/post.test.js
+++ b/pdr-api/handlers/fees/_tests_/post.test.js
@@ -27,7 +27,7 @@ describe('Create a Fee', () => {
         activity: 'test',
         billingBy: 'test',
         feeValue: 777,
-        chargeBy: 'night'
+        chargeBy: 'Night'
       },
       requestContext: {
         authorizer: {

--- a/pdr-api/template.yaml
+++ b/pdr-api/template.yaml
@@ -531,6 +531,7 @@ Resources:
       CodeUri: handlers/fees/POST
       Handler: index.handler
       Layers:
+        - !Ref DataUtilsLayer
         - !Ref BaseLayer
         - !Ref AWSUtilsLayer
       Runtime: nodejs18.x
@@ -563,6 +564,7 @@ Resources:
       CodeUri: handlers/fees/DELETE
       Handler: index.handler
       Layers:
+        - !Ref DataUtilsLayer
         - !Ref BaseLayer
         - !Ref AWSUtilsLayer
       Runtime: nodejs18.x


### PR DESCRIPTION
Ticket: [559](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=93717255&issue=bcgov%7Cparks-data-register%7C559)

Notes: 
- Add validation for chargeBy attributes and improve DELETE/POST handlers
- Added `FEES_OPTIONAL_PUT_FIELDS` validation to ensure only valid `chargeBy` attributes are allowed in POST and DELETE handlers.
- Updated `deleteParameter` to handle cases where the last `chargeBy` attribute cannot be deleted.
- Improved error handling in DELETE handler to return appropriate responses for missing or invalid items.
- Added new test cases for DELETE handler:
  - Prevent deletion of the last `chargeBy` attribute.
  - Handle invalid `chargeBy` attributes.
  - Handle missing fee records.
- Fixed test data and mock configurations for consistency.
- Updated `template.yaml` to include `DataUtilsLayer` for DELETE and POST handlers.