### PR TITLE
BRS-559: Change error codes to 400

### DIFF
--- a/pdr-api/handlers/fees/DELETE/index.js
+++ b/pdr-api/handlers/fees/DELETE/index.js
@@ -71,7 +71,7 @@ const deleteParameter = async (queryParams, context) => {
     case Object.keys(currentItem).length === 0:
       logger.error('Item not found in DynamoDB');
       throw {
-        code: 404,
+        code: 400,
         error: 'Not Found.',
         msg: `Item does not exist in DynamoDB.`
       };
@@ -131,7 +131,7 @@ const deleteWholeRecord = async (queryParams, context) => {
   if (Object.keys(currentItem).length === 0) {
     logger.error('Item not found in DynamoDB');
     throw {
-      code: 404,
+      code: 400,
       error: 'Not Found.',
       msg: `Item does not exist in DynamoDB.`
     };

--- a/pdr-api/handlers/fees/PUT/index.js
+++ b/pdr-api/handlers/fees/PUT/index.js
@@ -14,7 +14,7 @@ exports.handler = async (event, context) => {
   const isAdmin = event.requestContext?.authorizer?.isAdmin || false;
 
   if (!isAdmin) {
-    return sendResponse(403, [], 'Unauthorized', 'Unauthorized');
+    return sendResponse(400, [], 'Unauthorized', 'Unauthorized');
   }
 
   try {

--- a/pdr-api/handlers/fees/_tests_/delete.test.js
+++ b/pdr-api/handlers/fees/_tests_/delete.test.js
@@ -214,7 +214,7 @@ describe('Delete a Fee', () => {
     };
     const res = await lambda.handler(eventDelete, null);
     const body = JSON.parse(res.body);
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(400);
     expect(body.msg).toBe('Item does not exist in DynamoDB.');
   });
 

--- a/pdr-api/handlers/fees/_tests_/feesPut.test.js
+++ b/pdr-api/handlers/fees/_tests_/feesPut.test.js
@@ -106,7 +106,7 @@ describe('Update Fees Tests', () => {
     };
     const res = await lambda.handler(event, null);
     const body = JSON.parse(res.body);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(body.error).toBe('Unauthorized');
   });
 


### PR DESCRIPTION
Ticket: [559](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=93717255&issue=bcgov%7Cparks-data-register%7C559)
Notes: Changing Error codes to not use 403 or 404 as they were sending the html error page response in aws. The same as [Previous Sendback](https://github.com/bcgov/parks-data-register/pull/583)